### PR TITLE
Delegates

### DIFF
--- a/src/main/php/web/frontend/ClassesIn.class.php
+++ b/src/main/php/web/frontend/ClassesIn.class.php
@@ -1,0 +1,24 @@
+<?php namespace web\frontend;
+
+use lang\reflect\Package;
+
+/**
+ * Creates routing based on classes in a given package
+ */
+class ClassesIn extends Delegates {
+
+  /**
+   * Creates this delegates instance
+   *
+   * @param  lang.reflect.Package|string $package
+   * @param  function(lang.XPClass): object $new Optional function to create instances
+   */
+  public function __construct($package, $new= null) {
+    $p= $package instanceof Package ? $package : Package::forName($package);
+    foreach ($p->getClasses() as $class) {
+      if ($class->reflect()->isInstantiable()) {
+        $this->with($new ? $new($class) : $class->newInstance());
+      }
+    }
+  }
+}

--- a/src/main/php/web/frontend/Delegates.class.php
+++ b/src/main/php/web/frontend/Delegates.class.php
@@ -8,8 +8,14 @@ use lang\IllegalArgumentException;
 class Delegates {
   private $patterns= [];
 
-  /** @param object $instance */
-  public function __construct($instance) {
+  /**
+   * Routes to instance methods based on annotations
+   *
+   * @param  object $instance
+   * @return self
+   * @throws lang.IllegalArgumentException
+   */
+  public function with($instance) {
     if (!is_object($instance)) {
       throw new IllegalArgumentException('Expected an object, have '.typeof($instance));
     }
@@ -17,13 +23,14 @@ class Delegates {
     foreach (typeof($instance)->getMethods() as $method) {
       $name= $method->getName();
       foreach ($method->getAnnotations() as $verb => $segment) {
-        $p= $segment
+        $pattern= $segment
           ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
           : '.+'
         ;
-        $this->patterns['#'.$verb.$p.'$#']= new Delegate($instance, $method);
+        $this->patterns['#'.$verb.$pattern.'$#']= new Delegate($instance, $method);
       }
     }
+    return $this;
   }
 
   /**

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -12,12 +12,12 @@ class Frontend implements Handler {
   /**
    * Instantiates a new frontend
    *
-   * @param  object $handler
+   * @param  web.frontend.Delegates|object $arg
    * @param  web.frontend.Templates $templates
    * @param  string $base
    */
-  public function __construct($handler, Templates $templates, $base= '') {
-    $this->delegates= new Delegates($handler);
+  public function __construct($arg, Templates $templates, $base= '') {
+    $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->templates= $templates;
     $this->base= rtrim($base, '/');
   }

--- a/src/main/php/web/frontend/MethodsIn.class.php
+++ b/src/main/php/web/frontend/MethodsIn.class.php
@@ -1,0 +1,12 @@
+<?php namespace web\frontend;
+
+/**
+ * Creates routing based on a given instance
+ */
+class MethodsIn extends Delegates {
+
+  /** @param object $instance */
+  public function __construct($instance) {
+    $this->with($instance);
+  }
+}


### PR DESCRIPTION
Adds shorthand alternative to manually entering all routes:

```php
use web\Application;
use actions\{Users, Blogs};

class Service extends Application {
  public function routes() {
    $templates= ...
    return [
      // Route /users to methods inside Users class, and /blogs to Blogs, and so forth...
      '/users' => new Frontend(new Users(), $templates),
      '/blogs' => new Frontend(new Blogs(), $templates),

      // Sets up routes for all instantiable classes inside the "actions" package
      '/' => new Frontend(new ClassesIn('actions'), $templates),
    ];
  }
}
```