### PR TITLE
Allows to throw web.Error in handler

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -55,6 +55,9 @@ class Frontend implements Handler {
 
       $delegate->invoke($args, $this->templates)->transfer($req, $res, $this->base);
     } catch (TargetInvocationException $e) {
+      if ($e->getCause() instanceof Error) {
+        throw $e->getCause();
+      }
       throw new Error(500, $e->getCause());
     }
   }


### PR DESCRIPTION
At this point a web.Error thrown in a handler will be wrapped by another web.Error which causes the http status code set in this inner error to be lost.