### PR TITLE
Request in templates

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -100,7 +100,7 @@ class View {
       $res->flush();
     } else {
       $this->context['base']= $base;
-      $this->context['request']= ['params' => $req->params(), 'values' => $req->values()];
+      $this->context['request']= $req;
 
       $res->header('Content-Type', 'text/html; charset=utf-8');
       $out= $res->stream();

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -37,6 +37,22 @@ class HandlingTest extends TestCase {
     return $res;
   }
 
+  /**
+   * Assertion helper to compare template engine context
+   *
+   * @param  [:var] $expected
+   * @param  [:var] $actual
+   * @return void
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertContext($expected, $actual) {
+    $actual['request']= [
+      'params' => $actual['request']->params(),
+      'values' => $actual['request']->values(),
+    ];
+    $this->assertEquals($expected, $actual);
+  }
+
   #[@test]
   public function template_name_inferred_from_class_name() {
     $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
@@ -70,7 +86,7 @@ class HandlingTest extends TestCase {
     ]));
 
     $this->handle($fixture, 'GET', '/users/1');
-    $this->assertEquals(
+    $this->assertContext(
       ['id' => 1, 'name' => 'Test', 'base' => '', 'request' => [
         'params' => [],
         'values' => []
@@ -89,7 +105,7 @@ class HandlingTest extends TestCase {
 
     $return= ['start' => '1', 'max' => '100', 'list' => []];
     $this->handle($fixture, 'GET', $uri);
-    $this->assertEquals(
+    $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
         'params' => ['max' => '100', 'start' => '1'],
         'values' => []
@@ -108,7 +124,7 @@ class HandlingTest extends TestCase {
 
     $return= ['start' => 0, 'max' => -1, 'list' => [['id' => 1, 'name' => 'Test']]];
     $this->handle($fixture, 'GET', '/users');
-    $this->assertEquals(
+    $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
         'params' => [],
         'values' => []
@@ -127,7 +143,7 @@ class HandlingTest extends TestCase {
 
     $return= ['created' => 2];
     $this->handle($fixture, 'POST', '/users', [], 'username=New');
-    $this->assertEquals(
+    $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
         'params' => ['username' => 'New'],
         'values' => []
@@ -206,7 +222,7 @@ class HandlingTest extends TestCase {
 
     $return= ['category' => 'development', 'article' => 1];
     $res= $this->handle($fixture, 'GET', '/blogs/development/1');
-    $this->assertEquals(
+    $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
         'params' => [],
         'values' => []
@@ -224,7 +240,7 @@ class HandlingTest extends TestCase {
     ]));
 
     $this->handle($fixture, 'GET', '/', ['Cookie' => 'test=Works']);
-    $this->assertEquals(
+    $this->assertContext(
       ['home' => 'Works', 'base' => '', 'request' => [
         'params' => [],
         'values' => []

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -46,10 +46,7 @@ class HandlingTest extends TestCase {
    * @throws unittest.AssertionFailedError
    */
   private function assertContext($expected, $actual) {
-    $actual['request']= [
-      'params' => $actual['request']->params(),
-      'values' => $actual['request']->values(),
-    ];
+    $actual['request']= ['params' => $actual['request']->params()];
     $this->assertEquals($expected, $actual);
   }
 
@@ -88,8 +85,7 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'GET', '/users/1');
     $this->assertContext(
       ['id' => 1, 'name' => 'Test', 'base' => '', 'request' => [
-        'params' => [],
-        'values' => []
+        'params' => []
       ]],
       $result
     );
@@ -107,8 +103,7 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'GET', $uri);
     $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
-        'params' => ['max' => '100', 'start' => '1'],
-        'values' => []
+        'params' => ['max' => '100', 'start' => '1']
       ]]),
       $result
     );
@@ -126,8 +121,7 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'GET', '/users');
     $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
-        'params' => [],
-        'values' => []
+        'params' => []
       ]]),
       $result
     );
@@ -145,8 +139,7 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'POST', '/users', [], 'username=New');
     $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
-        'params' => ['username' => 'New'],
-        'values' => []
+        'params' => ['username' => 'New']
       ]]),
       $result
     );
@@ -224,8 +217,7 @@ class HandlingTest extends TestCase {
     $res= $this->handle($fixture, 'GET', '/blogs/development/1');
     $this->assertContext(
       array_merge($return, ['base' => '', 'request' => [
-        'params' => [],
-        'values' => []
+        'params' => []
       ]]),
       $result
     );
@@ -242,8 +234,7 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'GET', '/', ['Cookie' => 'test=Works']);
     $this->assertContext(
       ['home' => 'Works', 'base' => '', 'request' => [
-        'params' => [],
-        'values' => []
+        'params' => []
       ]],
       $result
     );


### PR DESCRIPTION
This pull request passes the full request object to the template engine context. This way, information like request method and URI are exposed and usable inside templates.

/cc @johannes85