### PR TITLE
Avoid the stack trace being part of the Error exeptions message

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -55,10 +55,11 @@ class Frontend implements Handler {
 
       $delegate->invoke($args, $this->templates)->transfer($req, $res, $this->base);
     } catch (TargetInvocationException $e) {
-      if ($e->getCause() instanceof Error) {
-        throw $e->getCause();
+      $cause= $e->getCause();
+      if ($cause instanceof Error) {
+        throw $cause;
       }
-      throw new Error(500, $e->getCause());
+      throw new Error(500, $cause->getMessage(), $cause);
     }
   }
 }

--- a/src/test/php/web/frontend/unittest/ClassesInTest.class.php
+++ b/src/test/php/web/frontend/unittest/ClassesInTest.class.php
@@ -24,6 +24,7 @@ class ClassesInTest extends TestCase {
         '#get/blogs/(?<category>[^/]+)/(?<id>[0-9]+)$#',
         '#get/users/(?<id>[^/]+)/avatar$#',
         '#get/users/(?<id>[^/]+)$#',
+        '#get/exception$#',
         '#post/users$#',
         '#get/users$#',
         '#get.+$#'

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\unittest;
 
+use lang\XPException;
 use unittest\TestCase;
 use web\Error;
 use web\Request;
@@ -238,5 +239,26 @@ class HandlingTest extends TestCase {
       ]],
       $result
     );
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= '/^test$/')]
+  public function error_exclude_stacktrace_in_message() {
+    $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
+      'write' => function($template, $context, $out) { /* NOOP */ }
+    ]));
+    $this->handle($fixture, 'GET', '/exception');
+  }
+
+  #[@test]
+  public function error_contains_cause() {
+    $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
+      'write' => function($template, $context, $out) { /* NOOP */ }
+    ]));
+    try {
+      $this->handle($fixture, 'GET', '/exception');
+    } catch (Error $ex) {
+      $this->assertTrue($ex->getCause() instanceof XPException);
+      $this->assertEquals('test', $ex->getMessage());
+    }
   }
 }

--- a/src/test/php/web/frontend/unittest/MethodsInTest.class.php
+++ b/src/test/php/web/frontend/unittest/MethodsInTest.class.php
@@ -18,8 +18,9 @@ class MethodsInTest extends TestCase {
       [
         '#get/users/(?<id>[^/]+)/avatar$#',
         '#get/users/(?<id>[^/]+)$#',
+        '#get/exception$#',
         '#post/users$#',
-        '#get/users$#',
+        '#get/users$#'
       ],
       array_keys($delegates->patterns)
     );

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\unittest\actions;
 
+use lang\XPException;
 use web\Error;
 use web\frontend\View;
 
@@ -42,5 +43,10 @@ class Users {
   #[@get('/users/{id}/avatar')]
   public function avatar($id) {
     // TBI
+  }
+
+  #[@get('/exception')]
+  public function exception() {
+    throw new XPException('test');
   }
 }


### PR DESCRIPTION
Using the original cause of the TargetInvocationException as message for Error caused the stack trace to be leaked to the browser, even when in the prod environment, since setting the message executes toString on the original Exception.

This change uses only the message of the original exception to set the message of the Error object. The full exception is set as cause for displaying the stack trace later (in xp-forge/web).

Also see: https://github.com/xp-forge/web/pull/59