### PR TITLE
Handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Frontends based on `xp-forge/web`.
 
 ## Example
 
-Frontend uses classes with methods annotated with HTTP verbs to handle routing. These methods return a context, which is passed along with the template name to the template engine.
+Frontend uses handler classes with methods annotated with HTTP verbs to handle routing. These methods return a context, which is passed along with the template name to the template engine.
 
 ```php
+#[@handler]
 class Home {
 
   #[@get, @$param: param('name')]

--- a/README.md
+++ b/README.md
@@ -82,3 +82,26 @@ class Site extends Application {
 ```
 
 To run it, use `xp -supervise web Site`, which will serve the site at http://localhost:8080/. Find and clone the example code [here](https://gist.github.com/thekid/8ce84b0d0de8fce5b6dd5faa22e1d716).
+
+## Organizing your code
+
+In real-life situations, you will not want to put all of your code into the `Home` class. In order to separate code out into various classes, place all handler classes inside a dedicated package:
+
+```bash
+@FileSystemCL<./src/main/php>
+package de.thekid.example.handlers {
+
+  public class de.thekid.example.handlers.Home
+  public class de.thekid.example.handlers.User
+  public class de.thekid.example.handlers.Group
+}
+```
+
+Then use the delegation API provided by the `HandlersIn` class:
+
+```php
+use web\frontend\{Frontend, HandlersIn};
+
+// ...inside the routes() method, as seen above:
+new Frontend(new HandlersIn('de.thekid.example.handlers'), $templates);
+```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ use io\Path;
 class Site extends Application {
 
   /** @return [:var] */
-  protected function routes() {
+  public function routes() {
     $files= new FilesFrom(new Path($this->environment->webroot(), 'src/main/webapp'));
     $templates= new TemplateEngine(new Path($this->environment->webroot(), 'src/main/handlebars'));
 

--- a/src/main/php/web/frontend/ClassesIn.class.php
+++ b/src/main/php/web/frontend/ClassesIn.class.php
@@ -3,7 +3,7 @@
 use lang\reflect\Package;
 
 /**
- * Creates routing based on handler classes in a given package
+ * Creates routing based on classes in a given package
  *
  * @deprecated Use HandlersIn instead
  */

--- a/src/main/php/web/frontend/Delegates.class.php
+++ b/src/main/php/web/frontend/Delegates.class.php
@@ -12,21 +12,24 @@ class Delegates {
    * Routes to instance methods based on annotations
    *
    * @param  object $instance
+   * @param  string $base
    * @return self
    * @throws lang.IllegalArgumentException
    */
-  public function with($instance) {
+  public function with($instance, $base= '/') {
     if (!is_object($instance)) {
       throw new IllegalArgumentException('Expected an object, have '.typeof($instance));
     }
 
+    $base= rtrim($base, '/');
     foreach (typeof($instance)->getMethods() as $method) {
       $name= $method->getName();
       foreach ($method->getAnnotations() as $verb => $segment) {
-        $pattern= $segment
-          ? preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment)
-          : '.+'
-        ;
+        if ('/' === $segment || null === $segment) {
+          $pattern= $base.'/?';
+        } else {
+          $pattern= $base.preg_replace(['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'], ['(?<$1>$2)', '(?<$1>[^/]+)'], $segment);
+        }
         $this->patterns['#'.$verb.$pattern.'$#']= new Delegate($instance, $method);
       }
     }

--- a/src/main/php/web/frontend/HandlersIn.class.php
+++ b/src/main/php/web/frontend/HandlersIn.class.php
@@ -3,7 +3,10 @@
 use lang\reflect\Package;
 
 /**
- * Creates routing based on handler classes in a given package
+ * Creates routing based on classes annotated with `@handler` in a
+ * given package.
+ *
+ * @test  xp://web.frontend.unittest.HandlersInTest
  */
 class HandlersIn extends Delegates {
 
@@ -16,8 +19,8 @@ class HandlersIn extends Delegates {
   public function __construct($package, $new= null) {
     $p= $package instanceof Package ? $package : Package::forName($package);
     foreach ($p->getClasses() as $class) {
-      if ($class->reflect()->isInstantiable()) {
-        $this->with($new ? $new($class) : $class->newInstance());
+      if ($class->hasAnnotation('handler')) {
+        $this->with($new ? $new($class) : $class->newInstance(), $class->getAnnotation('handler'));
       }
     }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });

--- a/src/main/php/web/frontend/HandlersIn.class.php
+++ b/src/main/php/web/frontend/HandlersIn.class.php
@@ -4,10 +4,8 @@ use lang\reflect\Package;
 
 /**
  * Creates routing based on handler classes in a given package
- *
- * @deprecated Use HandlersIn instead
  */
-class ClassesIn extends Delegates {
+class HandlersIn extends Delegates {
 
   /**
    * Creates this delegates instance

--- a/src/main/php/web/frontend/MethodsIn.class.php
+++ b/src/main/php/web/frontend/MethodsIn.class.php
@@ -1,5 +1,7 @@
 <?php namespace web\frontend;
 
+use lang\IllegalArgumentException;
+
 /**
  * Creates routing based on a given instance
  */
@@ -7,7 +9,12 @@ class MethodsIn extends Delegates {
 
   /** @param object $instance */
   public function __construct($instance) {
-    $this->with($instance);
+    $type= typeof($instance);
+    if (!is_object($instance)) {
+      throw new IllegalArgumentException('Expected an object, have '.$type);
+    }
+
+    $this->with($instance, $type->hasAnnotation('handler') ? $type->getAnnotation('handler') : '/');
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
   }
 }

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -26,7 +26,7 @@ class HandlersInTest extends TestCase {
         '#get/users/(?<id>[^/]+)$#',
         '#post/users$#',
         '#get/users$#',
-        '#get.+$#'
+        '#get/?$#'
       ],
       array_keys($delegates->patterns)
     );

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -2,23 +2,23 @@
 
 use lang\reflect\Package;
 use unittest\TestCase;
-use web\frontend\ClassesIn;
+use web\frontend\HandlersIn;
 
-class ClassesInTest extends TestCase {
+class HandlersInTest extends TestCase {
 
   #[@test]
   public function can_create_with_string() {
-    new ClassesIn('web.frontend.unittest.actions');
+    new HandlersIn('web.frontend.unittest.actions');
   }
 
   #[@test]
   public function can_create_with_package() {
-    new ClassesIn(Package::forName('web.frontend.unittest.actions'));
+    new HandlersIn(Package::forName('web.frontend.unittest.actions'));
   }
 
   #[@test]
   public function patterns_sorted_by_length() {
-    $delegates= new ClassesIn('web.frontend.unittest.actions');
+    $delegates= new HandlersIn('web.frontend.unittest.actions');
     $this->assertEquals(
       [
         '#get/blogs/(?<category>[^/]+)/(?<id>[0-9]+)$#',

--- a/src/test/php/web/frontend/unittest/actions/Blogs.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Blogs.class.php
@@ -1,8 +1,9 @@
 <?php namespace web\frontend\unittest\actions;
 
+#[@handler('/blogs')]
 class Blogs {
 
-  #[@get('/blogs/{category}/{id:[0-9]+}')]
+  #[@get('/{category}/{id:[0-9]+}')]
   public function article($category, $id) {
     return ['category' => $category, 'article' => (int)$id];
   }

--- a/src/test/php/web/frontend/unittest/actions/Home.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Home.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\unittest\actions;
 
+#[@handler]
 class Home {
 
   #[@get, @$req: request]

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -3,6 +3,7 @@
 use web\Error;
 use web\frontend\View;
 
+#[@handler]
 class Users {
   private $list= [
     1 => ['id' => 1, 'name' => 'Test'],
@@ -46,5 +47,4 @@ class Users {
     }
     return $this->list[$id]['avatar'];  // Raises an exception if key is undefined!
   }
-
 }


### PR DESCRIPTION
This pull request creates a new `HandlersIn` class to supersede `ClassesIn`, which is now deprecated. Because the old implementation will simply register any instantiable class as delegate, there's no real way to put DTOs and related code next to the handler classes; instead, these would always need to be in a separate package. Refactoring code means replacing *ClassesIn* With *HandlersIn* inside the application **and** adding the `@handler` annotation to all classes.

⚠️ Keeps BC *until next major release* by retaining the `ClassesIn` class. See also https://github.com/xp-forge/rest-api/pull/10

Below is the rendered documentation on the *HandlersIn* class from *README.md*:

* * * 

## Organizing your code

In real-life situations, you will not want to put all of your code into the `Home` class. In order to separate code out into various classes, place all handler classes inside a dedicated package:

```bash
@FileSystemCL<./src/main/php>
package de.thekid.example.handlers {

  public class de.thekid.example.handlers.Home
  public class de.thekid.example.handlers.User
  public class de.thekid.example.handlers.Group
}
```

Then use the delegation API provided by the `HandlersIn` class:

```php
use web\frontend\{Frontend, HandlersIn};

// ...inside the routes() method, as seen above:
new Frontend(new HandlersIn('de.thekid.example.handlers'), $templates);
```
