### PR TITLE
Add handler to serve frontend assets

### DIFF
--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -1,0 +1,112 @@
+<?php namespace web\frontend;
+
+use io\Path;
+use util\MimeType;
+use web\{Handler, Headers};
+
+/**
+ * Serves assets from a given path. Checks for files with extensions matching
+ * the encodings passed in the `Accept-Encoding` header before falling back to
+ * the original file name.
+ *
+ * @test web.frontend.unittest.AssetsFromTest
+ * @see  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
+ */
+class AssetsFrom implements Handler {
+  const EXTENSIONS = [
+    'br'       => '.br',
+    'gzip'     => '.gz',
+    'deflate'  => '.dfl',
+    'bzip2'    => '.bz2',
+    'identity' => '',
+    '*'        => ''
+  ];
+
+  private $path;
+
+  /**
+   * Instantiate an asset handler. Serves assets from the given path, using
+   * a given maximum age (in seconds) for the cache control header.
+   *
+   * @param  io.Path|io.Folder|string $path
+   * @param  int $cacheFor
+   */
+  public function __construct($path, $cacheFor= 2419200) {
+    $this->path= $path instanceof Path ? $path : new Path($path);
+    $this->cacheFor= $cacheFor;
+  }
+
+  /**
+   * Returns encodings accepted by the client ordered by given qvalues.
+   * Guarantees a "*" value to exist, which selects the uncompressed file.
+   *
+   * @param  string $header
+   * @return [:float]
+   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding
+   */
+  public static function accepted($header) {
+    $r= [];
+    $o= 0;
+    $s= 1.0;
+    while ($o < strlen($header)) {
+      $o+= ' ' === $header[$o];
+      $p= strcspn($header, ',;', $o);
+      $value= substr($header, $o, $p);
+      $o+= $p;
+
+      if (';' === ($header[$o] ?? null)) {
+        $p= strcspn($header, ',', $o);
+        sscanf(substr($header, $o + 1, $p - 1), 'q=%f', $q);
+        $o+= $p;
+      } else {
+        $q= $s-= 0.01;
+      }
+      $o++;
+      $r[$value]= $q;
+    }
+
+    $r+= ['*' => 0.01];
+    arsort($r, SORT_NUMERIC);
+    return $r;
+  }
+
+  /**
+   * Handling implementation, serves files including handling of conditional
+   * `If-Modified-Since` logic.
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   * @return var
+   */
+  public function handle($request, $response) {
+    $path= $request->uri()->path();
+    $file= null;
+    foreach (self::accepted($request->header('Accept-Encoding', '')) as $encoding => $q) {
+      $target= new Path($this->path, $path.(self::EXTENSIONS[$encoding] ?? '*'));
+      if ($target->exists()) {
+        $file= $target->asFile();
+        '*' === $encoding || $response->header('Content-Encoding', $encoding);
+        break;
+      }
+    }
+
+    if (null === $file) {
+      $response->answer(404, 'Not Found');
+      $response->send('The asset \''.$path.'\' was not found', 'text/plain');
+      return;
+    }
+
+    $modified= $file->lastModified();
+    if (($conditional= $request->header('If-Modified-Since')) && $modified <= strtotime($conditional)) {
+      $response->answer(304, 'Not Modified');
+      $response->flush();
+      return;
+    }
+
+    $response->answer(200, 'OK');
+    $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $modified));
+    $response->header('X-Content-Type-Options', 'nosniff');
+    $response->header('Cache-Control', 'max-age='.$this->cacheFor.', must-revalidate');
+    $response->transfer($file->in(), MimeType::getByFileName($path), $file->size());
+  }
+}

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -29,11 +29,9 @@ class AssetsFrom implements Handler {
    * a given maximum age (in seconds) for the cache control header.
    *
    * @param  io.Path|io.Folder|string $path
-   * @param  int $cacheFor
    */
-  public function __construct($path, $cacheFor= 2419200) {
+  public function __construct($path) {
     $this->path= $path instanceof Path ? $path : new Path($path);
-    $this->cacheFor= $cacheFor;
   }
 
   /**
@@ -106,7 +104,6 @@ class AssetsFrom implements Handler {
     $response->answer(200, 'OK');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $modified));
     $response->header('X-Content-Type-Options', 'nosniff');
-    $response->header('Cache-Control', 'max-age='.$this->cacheFor.', must-revalidate');
     $response->transfer($file->in(), MimeType::getByFileName($path), $file->size());
   }
 }

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -116,7 +116,7 @@ class AssetsFrom implements Handler {
     $response->answer(200, 'OK');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $modified));
     $response->header('X-Content-Type-Options', 'nosniff');
-    $headers= $this->headers instanceof \Closure ? ($this->headers)($file) : $this->headers;
+    $headers= is_callable($this->headers) ? ($this->headers)($file) : $this->headers;
     foreach ($headers as $name => $value) {
       $response->header($name, $value);
     }

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -23,6 +23,7 @@ class AssetsFrom implements Handler {
   ];
 
   private $path;
+  private $headers= [];
 
   /**
    * Instantiate an asset handler. Serves assets from the given path, using
@@ -32,6 +33,17 @@ class AssetsFrom implements Handler {
    */
   public function __construct($path) {
     $this->path= $path instanceof Path ? $path : new Path($path);
+  }
+
+  /**
+   * Adds headers, either from an array or a function.
+   *
+   * @param  [:string]|function(io.File): iterable $headers
+   * @return self
+   */
+  public function with($headers) {
+    $this->headers= $headers;
+    return $this;
   }
 
   /**
@@ -104,6 +116,11 @@ class AssetsFrom implements Handler {
     $response->answer(200, 'OK');
     $response->header('Last-Modified', gmdate('D, d M Y H:i:s T', $modified));
     $response->header('X-Content-Type-Options', 'nosniff');
+    $headers= $this->headers instanceof \Closure ? ($this->headers)($file) : $this->headers;
+    foreach ($headers as $name => $value) {
+      $response->header($name, $value);
+    }
+
     $response->transfer($file->in(), MimeType::getByFileName($path), $file->size());
   }
 }

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -1,0 +1,180 @@
+<?php namespace web\frontend\unittest;
+
+use io\{Files, File, Folder};
+use lang\Environment;
+use unittest\{After, Assert, Test, Values};
+use web\frontend\AssetsFrom;
+use web\io\{TestInput, TestOutput};
+use web\{Request, Response};
+
+class AssetsFromTest {
+  const CONTENTS = 'body { color: red; }';
+  const COMPRESSED = "^_\x8B>^H^\x002d_...";
+
+  private $remove= [];
+
+  /**
+   * Creates a temporary folder
+   *
+   * @param  [:string] $files
+   * @return io.Folder
+   */
+  private function folderWith($files) {
+    $f= new Folder(Environment::tempDir(), uniqid());
+    $f->create();
+    foreach ($files as $name => $content) {
+      Files::write(new File($f, $name), $content);
+    }
+    return $this->remove[]= $f;
+  }
+
+  /**
+   * Serve a GET request from the specified files
+   *
+   * @param  [:string] $files
+   * @param  string $path
+   * @param  [:string] $headers
+   * @return web.Response
+   */
+  private function serve($files, $path, $headers= []) {
+    $req= new Request(new TestInput('GET', $path, $headers));
+    $res= new Response(new TestOutput());
+
+    (new AssetsFrom($this->folderWith($files)))->handle($req, $res);
+    return $res;
+  }
+
+  /**
+   * Assertion helper
+   *
+   * @param  string $bytes
+   * @param  web.Response $res
+   * @throws unittest.AssertionFailedError
+   * @return void
+   */
+  private function assertFile($bytes, $res) {
+    Assert::equals("\r\n\r\n$bytes", strstr($res->output()->bytes(), "\r\n\r\n"));
+  }
+
+  #[Test]
+  public function can_create() {
+    new AssetsFrom('.');
+  }
+
+  #[Test]
+  public function can_create_with_folder() {
+    new AssetsFrom(new Folder('.'));
+  }
+
+  #[Test]
+  public function typical_ua_header_accepted() {
+    Assert::equals(
+      ['gzip' => 0.99, 'deflate' => 0.98, 'br' => 0.97, '*' => 0.01],
+      AssetsFrom::accepted('gzip, deflate, br')
+    );
+  }
+
+  #[Test]
+  public function identity_accepted() {
+    Assert::equals(
+      ['identity' => 0.99, '*' => 0.01],
+      AssetsFrom::accepted('identity')
+    );
+  }
+
+  #[Test]
+  public function header_with_qvalues_accepted() {
+    Assert::equals(
+      ['gzip' => 1.0, 'deflate' => 0.99, '*' => 0.5],
+      AssetsFrom::accepted('deflate, gzip;q=1.0, *;q=0.5')
+    );
+  }
+
+  #[Test, Values([null, 'deflate', 'gzip, deflate'])]
+  public function directly_serves_file($for) {
+    $files= ['fixture.css' => self::CONTENTS];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => $for]);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::false(isset($res->headers()['Content-Encoding']));
+    $this->assertFile($files['fixture.css'], $res);
+  }
+
+  #[Test, Values([[['fixture.css' => self::CONTENTS]], [['fixture.css.gz' => self::COMPRESSED]]])]
+  public function handles_conditional_requests($files) {
+    $res= $this->serve($files, '/fixture.css', [
+      'Accept-Encoding'   => 'gzip, deflate, br',
+      'If-Modified-Since' => gmdate('D, d M Y H:i:s T', time() + 86400)
+    ]);
+
+    Assert::equals(304, $res->status());
+  }
+
+  #[Test]
+  public function returns_error_when_file_is_not_found() {
+    $files= ['fixture.css' => self::CONTENTS];
+    $res= $this->serve($files, '/nonexistant.css');
+
+    Assert::equals(404, $res->status());
+  }
+
+  #[Test, Values([['fixture.css.gz', 'gzip'], ['fixture.css.br', 'br'], ['fixture.css.dfl', 'deflate'], ['fixture.css.bz2', 'bzip2']])]
+  public function serves_compressed_when_gz_file_present($file, $encoding) {
+    $files= [$file => self::COMPRESSED];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => 'gzip, bzip2, deflate, br']);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::equals($encoding, $res->headers()['Content-Encoding']);
+    $this->assertFile($files[$file], $res);
+  }
+
+  #[Test]
+  public function prefers_gzip_compressed_when_gz_file_present() {
+    $files= ['fixture.css' => self::CONTENTS, 'fixture.css.gz' => self::COMPRESSED];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => 'gzip, br']);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::equals('gzip', $res->headers()['Content-Encoding']);
+    $this->assertFile($files['fixture.css.gz'], $res);
+  }
+
+  #[Test]
+  public function prefers_uncompressed_for_identity() {
+    $files= ['fixture.css' => self::CONTENTS, 'fixture.css.gz' => self::COMPRESSED];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => 'identity;q=1.0, gzip']);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::equals('identity', $res->headers()['Content-Encoding']);
+    $this->assertFile($files['fixture.css'], $res);
+  }
+
+  #[Test, Values([null, 'deflate', 'br, deflate;q=0.5', 'test'])]
+  public function prefers_uncompressed_without_browser_support($for) {
+    $files= ['fixture.css' => self::CONTENTS, 'fixture.css.gz' => self::COMPRESSED];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => $for]);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::false(isset($res->headers()['Content-Encoding']));
+    $this->assertFile($files['fixture.css'], $res);
+  }
+
+  #[Test, Values([null, 'deflate', 'br, deflate;q=0.5', 'test'])]
+  public function returns_error_without_browser_support($for) {
+    $files= ['fixture.css.gz' => self::COMPRESSED];
+    $res= $this->serve($files, '/fixture.css', ['Accept-Encoding' => $for]);
+
+    Assert::equals(404, $res->status());
+  }
+
+  #[After]
+  public function cleanup() {
+    foreach ($this->remove as $folder) {
+      $folder->unlink();
+    }
+  }
+}

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -59,8 +59,15 @@ class AssetsFromTest {
   /** @return iterable */
   private function headers() {
     yield [['Cache-Control' => 'no-cache']];
+
     yield [function($file) {
       if (strstr($file->filename, 'fixture')) {
+        yield 'Cache-Control' => 'no-cache';
+      }
+    }];
+
+    yield [new class() {
+      public function __invoke($file) {
         yield 'Cache-Control' => 'no-cache';
       }
     }];


### PR DESCRIPTION
Basically the same as `web.handlers.FilesFrom` (*and can serve as a snap-in replacement as seen below*), but with support for compressed files (`Accept-Encoding: gzip` will also check for `[file].gz`).

## Usage
Here's an example of how to refactor your app:

```diff
--- a/src/main/php/com/example/skills/App.php
+++ b/src/main/php/com/example/skills/App.php
@@ -3,8 +3,7 @@
 use inject\{Injector, Bindings};
 use security\credentials\{Credentials, FromEnvironment, FromFile};
 use web\frontend\helpers\Dates;
-use web\frontend\{Frontend, HandlersIn, Handlebars};
-use web\handler\FilesFrom;
+use web\frontend\{Frontend, HandlersIn, AssetsFrom, Handlebars};
 use web\rest\{RestApi, ResourcesIn};
 use web\session\{Sessions, InFileSystem, Cookies};
 use web\{Application, Filters};
@@ -30,10 +29,10 @@ class App extends Application {
     $inject->bind(Sessions::class, $sessions);

     $auth= $inject->get(Office365Integration::class)->using($sessions);
-    $files= new FilesFrom($this->environment->path('src/main/webapp'));
+    $assets= new AssetsFrom($this->environment->path('src/main/webapp'));
     return [
-      '/favicon.ico' => $files,
-      '/static'      => $files,
+      '/favicon.ico' => $assets,
+      '/static'      => $assets,
       '/files'       => $auth->required($inject->get(Binaries::class)),
       '/api'         => $auth->required(new RestApi(
         new ResourcesIn('com.example.skills.api', [$inject, 'get'])
```

## Compressing files

The handler will not do this on the fly, because you most probably know what you're able to compress and what not during *build* time. Our starting point:

```bash
$ du -h src/main/webapp/static/*css src/main/webapp/static/*js
12K     src/main/webapp/static/editor.css
1.4M    src/main/webapp/static/vendor.css
376K    src/main/webapp/static/editor.js
796K    src/main/webapp/static/vendor.js
```

To compress them, use the following (*by using `-k`, we keep the original files, which we'll deliver to all user agents that do not support compression!*):

```bash
$ gzip -k src/main/webapp/static/*css src/main/webapp/static/*js
```

The savings are noticeable:

```bash
$ du -h src/main/webapp/static/*gz
3.0K    src/main/webapp/static/editor.css.gz
124K    src/main/webapp/static/editor.js.gz
160K    src/main/webapp/static/vendor.css.gz
232K    src/main/webapp/static/vendor.js.gz
```

## Caching

Same API as with `FilesFrom` seen in xp-forge/web#74 (*though not dependant on this pull request being merged!*)

```php
// Always use no-cache
$assets= (new AssetsFrom($path))->with(['Cache-Control' => 'no-cache']);

// Decide caching strategy based on file
$assets= (new AssetsFrom($path))->with(function($file) {
  if (strstr($file->filename, '.html')) {
    yield 'Cache-Control' => 'no-cache';
  }
});
```

See also xp-forge/web#71

## Outcome

Before:

![image](https://user-images.githubusercontent.com/696742/112732982-8dd11900-8f3d-11eb-926c-83eb4eb8595d.png)

After:

![image](https://user-images.githubusercontent.com/696742/112732977-86aa0b00-8f3d-11eb-9c75-8669594e1658.png)


See also https://github.com/xp-forge/frontend/pull/12#issuecomment-808738164