### PR TITLE
Set Cache-Control to no-cache & allow overwriting via View::cache()

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -5,7 +5,7 @@ class View {
   public $templates;
   public $status= 200;
   public $context= [];
-  public $headers= [];
+  public $headers= ['Cache-Control' => 'no-cache'];
 
   /** @param string $template */
   private function __construct($template) {
@@ -78,6 +78,17 @@ class View {
    */
   public function using($templates) {
     $this->templates= $templates;
+    return $this;
+  }
+
+  /**
+   * Sets `Cache-Control` to header, which defaults to "no-cache"
+   *
+   * @param  string $control Header value
+   * @return self
+   */
+  public function cache($control) {
+    $this->headers['Cache-Control']= $control;
     return $this;
   }
 

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -84,6 +84,7 @@ class View {
   /**
    * Sets `Cache-Control` to header, which defaults to "no-cache"
    *
+   * @see    https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Cache-Control
    * @param  string $control Header value
    * @return self
    */

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -84,7 +84,7 @@ class View {
   /**
    * Sets `Cache-Control` to header, which defaults to "no-cache"
    *
-   * @see    https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Cache-Control
+   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
    * @param  string $control Header value
    * @return self
    */

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -24,6 +24,7 @@ class HandlersInTest extends TestCase {
         '#get/blogs/(?<category>[^/]+)/(?<id>[0-9]+)$#',
         '#get/users/(?<id>[^/]+)/avatar$#',
         '#get/users/(?<id>[^/]+)$#',
+        '#get/blogs/?$#',
         '#post/users$#',
         '#get/users$#',
         '#get/?$#'

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -281,27 +281,25 @@ class HandlingTest extends TestCase {
 
   #[Test]
   public function defaults_to_no_caching() {
-    $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
+    $fixture= new Frontend(new Blogs(), newinstance(Templates::class, [], [
       'write' => function($template, $context= [], $out) {
         // NOOP
       }
     ]));
 
-    $res= $this->handle($fixture, 'GET', '/users');
+    $res= $this->handle($fixture, 'GET', '/blogs');
     $this->assertEquals('no-cache', $res->headers()['Cache-Control']);
   }
 
   #[Test]
   public function view_can_set_caching() {
-    $users= new Users();
-    $users->list[1]= ['id' => 1, 'name' => 'Test', 'avatar' => 'PNG...'];
-    $fixture= new Frontend($users, newinstance(Templates::class, [], [
+    $fixture= new Frontend(new Blogs(), newinstance(Templates::class, [], [
       'write' => function($template, $context= [], $out) {
         // NOOP
       }
     ]));
 
-    $res= $this->handle($fixture, 'GET', '/users/1/avatar');
+    $res= $this->handle($fixture, 'GET', '/blogs/development/1');
     $this->assertEquals('max-age=2419200, must-revalidate', $res->headers()['Cache-Control']);
   }
 }

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -269,13 +269,39 @@ class HandlingTest extends TestCase {
   #[Test]
   public function content_type_headers() {
     $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
-      'write' => function($template, $context= [], $out) use(&$result) {
-        $result= $template;
+      'write' => function($template, $context= [], $out) {
+        // NOOP
       }
     ]));
 
     $res= $this->handle($fixture, 'GET', '/users');
     $this->assertEquals('text/html; charset=utf-8', $res->headers()['Content-Type']);
     $this->assertEquals('nosniff', $res->headers()['X-Content-Type-Options']);
+  }
+
+  #[Test]
+  public function defaults_to_no_caching() {
+    $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
+      'write' => function($template, $context= [], $out) {
+        // NOOP
+      }
+    ]));
+
+    $res= $this->handle($fixture, 'GET', '/users');
+    $this->assertEquals('no-cache', $res->headers()['Cache-Control']);
+  }
+
+  #[Test]
+  public function view_can_set_caching() {
+    $users= new Users();
+    $users->list[1]= ['id' => 1, 'name' => 'Test', 'avatar' => 'PNG...'];
+    $fixture= new Frontend($users, newinstance(Templates::class, [], [
+      'write' => function($template, $context= [], $out) {
+        // NOOP
+      }
+    ]));
+
+    $res= $this->handle($fixture, 'GET', '/users/1/avatar');
+    $this->assertEquals('max-age=2419200, must-revalidate', $res->headers()['Cache-Control']);
   }
 }

--- a/src/test/php/web/frontend/unittest/actions/Blogs.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Blogs.class.php
@@ -1,12 +1,20 @@
 <?php namespace web\frontend\unittest\actions;
 
-use web\frontend\{Get, Handler};
+use web\frontend\{Get, Handler, View};
 
 #[Handler('/blogs')]
 class Blogs {
 
+  #[Get]
+  public function index() {
+    return ['development' => [1]];
+  }
+
   #[Get('/{category}/{id:[0-9]+}')]
   public function article($category, $id) {
-    return ['category' => $category, 'article' => (int)$id];
+    return View::named('blog')
+      ->with(['category' => $category, 'article' => (int)$id])
+      ->cache('max-age=2419200, must-revalidate')
+    ;
   }
 }

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -5,7 +5,7 @@ use web\frontend\{View, Handler, Get, Post, Param};
 
 #[Handler]
 class Users {
-  public $list= [
+  private $list= [
     1 => ['id' => 1, 'name' => 'Test'],
   ];
 
@@ -53,6 +53,6 @@ class Users {
     if (!isset($this->list[$id])) {
       throw new Error(404, 'No such user '.$id);
     }
-    return View::named('svg')->with(['image' => $this->list[$id]['avatar']])->cache('max-age=2419200, must-revalidate');
+    return $this->list[$id]['avatar'];  // Raises an exception if key is undefined!
   }
 }

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -5,7 +5,7 @@ use web\frontend\{View, Handler, Get, Post, Param};
 
 #[Handler]
 class Users {
-  private $list= [
+  public $list= [
     1 => ['id' => 1, 'name' => 'Test'],
   ];
 
@@ -53,6 +53,6 @@ class Users {
     if (!isset($this->list[$id])) {
       throw new Error(404, 'No such user '.$id);
     }
-    return $this->list[$id]['avatar'];  // Raises an exception if key is undefined!
+    return View::named('svg')->with(['image' => $this->list[$id]['avatar']])->cache('max-age=2419200, must-revalidate');
   }
 }


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

## Example

```php
use web\frontend\{View, Handler, Get};

#[Handler]
class Blog {

  public function __construct(private Database $database) { }

  #[Get]
  public function index() {
    return $this->database->newest();
  }

  #[Get('/{id}')]
  public function article($id) {
    $article= $this->database->article($id);
    return View::named('article')->with($article)->cache('max-age=604800, must-revalidate');
  }
}
```

The *index* handler will use a `Cache-Control: no-cache` (which is the default), while the *article*  handler will overwrite this according to the recommendation from [the Cache-Control issue](https://github.com/xp-forge/web/issues/71#issuecomment-803468156):

> For dynamic pages which are unfrequently updated (say, a blog), we can cache a little bit more using Cache-Control: max-age=604800, must-revalidate (quote: This tells the browser to cache the HTML page for one week (604,800 seconds), and once that week is up, we need to check with the server for updates.)