### PR TITLE
Introduce globals, which are passed to the template context

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -4,19 +4,20 @@ use lang\reflect\TargetInvocationException;
 use web\{Error, Handler};
 
 class Frontend implements Handler {
-  private $delegates, $templates, $base;
+  private $delegates, $templates;
+  public $globals;
 
   /**
    * Instantiates a new frontend
    *
    * @param  web.frontend.Delegates|object $arg
    * @param  web.frontend.Templates $templates
-   * @param  string $base
+   * @param  [:var] $globals
    */
-  public function __construct($arg, Templates $templates, $base= '') {
+  public function __construct($arg, Templates $templates, $globals= []) {
     $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->templates= $templates;
-    $this->base= rtrim($base, '/');
+    $this->globals= is_string($globals) ? ['base' => rtrim($globals, '/')] : $globals;
   }
 
   /**
@@ -51,7 +52,7 @@ class Frontend implements Handler {
         }
       }
 
-      $delegate->invoke($args, $this->templates)->transfer($req, $res, $this->base);
+      $delegate->invoke($args, $this->templates)->transfer($req, $res, $this->globals);
     } catch (TargetInvocationException $e) {
       $cause= $e->getCause();
       if ($cause instanceof Error) {

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -98,10 +98,10 @@ class View {
    *
    * @param  web.Request $req
    * @param  web.Response $res
-   * @param  string $base
+   * @param  [:var] $globals
    * @return void
    */
-  public function transfer($req, $res, $base) {
+  public function transfer($req, $res, $globals) {
     $res->answer($this->status);
     foreach ($this->headers as $name => $value) {
       $res->header($name, $value);
@@ -111,7 +111,7 @@ class View {
       $res->header('Content-Length', 0);
       $res->flush();
     } else {
-      $this->context['base']= $base;
+      $this->context+= $globals;
       $this->context['request']= $req;
 
       // See https://webhint.io/docs/user-guide/hints/hint-x-content-type-options/

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -24,4 +24,20 @@ class FrontendTest extends TestCase {
   public function first_argument_must_be_object() {
     new Frontend(null, $this->templates);
   }
+
+  #[Test]
+  public function globals_empty_by_default() {
+    $this->assertEquals([], (new Frontend(new Users(), $this->templates))->globals);
+  }
+
+  #[Test]
+  public function globals_passed_to_constructor() {
+    $globals= ['base' => '/', 'fingerprint' => '99b3825'];
+    $this->assertEquals($globals, (new Frontend(new Users(), $this->templates, $globals))->globals);
+  }
+
+  #[Test]
+  public function base_passed_to_constructor() {
+    $this->assertEquals(['base' => ''], (new Frontend(new Users(), $this->templates, '/'))->globals);
+  }
 }

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -209,10 +209,7 @@ class HandlingTest extends TestCase {
 
     $return= ['category' => 'development', 'article' => 1];
     $res= $this->handle($fixture, 'GET', '/blogs/development/1');
-    $this->assertContext(
-      $return + ['request' => ['params' => []]],
-      $result
-    );
+    $this->assertContext($return + ['request' => ['params' => []]], $result);
   }
 
   #[Test]
@@ -225,10 +222,7 @@ class HandlingTest extends TestCase {
     ]), $globals);
 
     $this->handle($fixture, 'GET', '/');
-    $this->assertContext(
-      $globals + ['home' => null, 'request' => ['params' => []]],
-      $result
-    );
+    $this->assertContext($globals + ['home' => null, 'request' => ['params' => []]], $result);
   }
 
   #[Test]
@@ -241,10 +235,7 @@ class HandlingTest extends TestCase {
     ]), $globals);
 
     $this->handle($fixture, 'GET', '/');
-    $this->assertContext(
-      ['home' => null, 'request' => ['params' => []]],
-      $result
-    );
+    $this->assertContext(['home' => null, 'request' => ['params' => []]], $result);
   }
 
   #[Test]
@@ -256,10 +247,7 @@ class HandlingTest extends TestCase {
     ]));
 
     $this->handle($fixture, 'GET', '/', ['Cookie' => 'test=Works']);
-    $this->assertContext(
-      ['home' => 'Works', 'request' => ['params' => []]],
-      $result
-    );
+    $this->assertContext(['home' => 'Works', 'request' => ['params' => []]], $result);
   }
 
   #[Test]


### PR DESCRIPTION
Passing a map to the frontend constructor will merge this map into the template context:

```php
new Frontend(
  new HandlersIn('com.example.skills.web'),
  new Handlebars($this->environment->path('src/main/handlebars')),
  ['assets' => '/assets/'.$fingerprint]
)
```

The previous parameter here was *base*, a string which would be passed as "base" in the template context. If a string is used, this behavior is retained.

See https://github.com/xp-forge/frontend/issues/15#issuecomment-812842250