### PR TITLE
Implement asset fingerprinting

### DIFF
--- a/src/main/php/web/frontend/AssetsManifest.class.php
+++ b/src/main/php/web/frontend/AssetsManifest.class.php
@@ -2,11 +2,32 @@
 
 use text\json\{Json, Input, FileInput};
 
+/**
+ * Assets manifest 
+ *
+ * @see   https://webpack.js.org/concepts/manifest/
+ * @test  web.frontend.unittest.AssetsManifestTest
+ */
 class AssetsManifest {
   public $assets;
 
   /** @param text.json.Input|io.Path|io.File|string */
   public function __construct($arg) {
     $this->assets= Json::read($arg instanceof Input ? $arg : new FileInput($arg));
+  }
+
+  /**
+   * Returns an immutable cache header if a file is contained in this
+   * manifest.
+   *
+   * @param  io.Path|io.File|string $file
+   * @return ?string
+   */
+  public function immutable($file) {
+    $compare= $file instanceof File ? $file->filename : (string)$file;
+    foreach ($this->assets as $resolved) {
+      if (0 === strpos($compare, $resolved)) return 'max-age=31536000, immutable';
+    }
+    return null;
   }
 }

--- a/src/main/php/web/frontend/AssetsManifest.class.php
+++ b/src/main/php/web/frontend/AssetsManifest.class.php
@@ -1,0 +1,12 @@
+<?php namespace web\frontend;
+
+use text\json\{Json, Input, FileInput};
+
+class AssetsManifest {
+  public $assets;
+
+  /** @param text.json.Input|io.Path|io.File|string */
+  public function __construct($arg) {
+    $this->assets= Json::read($arg instanceof Input ? $arg : new FileInput($arg));
+  }
+}

--- a/src/main/php/web/frontend/AssetsManifest.class.php
+++ b/src/main/php/web/frontend/AssetsManifest.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend;
 
+use io\File;
 use text\json\{Json, Input, FileInput};
 
 /**

--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -28,6 +28,10 @@ use util\profiling\Timer;
  *   ```sh
  *   $ xp bundle src/main/webapp/static
  *   ```
+ * - Create an asset manifest
+ *   ```sh
+ *   $ xp bundle -m manifest.json src/main/webapp/static
+ *   ```
  * - Use supplied configuration file instead of `./package.json`
  *   ```sh
  *   $ xp bundle -c ../package.json dist
@@ -43,10 +47,11 @@ use util\profiling\Timer;
 class BundleRunner {
 
   /** Displays success message */
-  private static function success(int $bundles, float $elapsed): int {
+  private static function success(int $bundles, bool $manifest, float $elapsed): int {
     Console::$out->writeLinef(
-      "\e[32mBundle operations: %d bundle(s) created in %.3f seconds using %.2f kB memory\e[0m",
+      "\e[32mBundle operations: %d bundle(s)%s created in %.3f seconds using %.2f kB memory\e[0m",
       $bundles,
+      $manifest ? ' + manifest' : '',
       $elapsed,
       Runtime::getInstance()->peakMemoryUsage() / 1024
     );
@@ -62,11 +67,14 @@ class BundleRunner {
   /** Entry point */
   public static function main(array $args): int {
     $config= 'package.json';
-    $target= 'static';
+    $manifest= null;
     $force= false;
+    $target= 'static';
     for ($i= 0, $s= sizeof($args); $i < $s; $i++) {
       if ('-c' === $args[$i]) {
         $config= $args[++$i];
+      } else if ('-m' === $args[$i]) {
+        $manifest= new Manifest($args[++$i]);
       } else if ('-f' === $args[$i]) {
         $force= true;
       } else {
@@ -126,19 +134,37 @@ class BundleRunner {
         }
 
         foreach ($result->sources() as $type => $source) {
-          $bundle= with ($source, new Bundle($target, $name.'.'.$type), function($in, $target) {
+          $compound= rtrim(strtr($name, ['[contenthash]' => '']), '.').'.'.$type;
+          $resolved= rtrim(strtr($name, ['[contenthash]' => substr($source->hash, 0, 7)]), '.').'.'.$type;
+          $manifest && $manifest->associate($compound, $resolved);
+          $bundle= with ($source, new Bundle($target, $resolved), function($in, $target) {
             $in->transfer($target);
             return $target;
           });
 
           foreach ($bundle->files() as $file) {
-            $path= str_replace($cwd->getURI(), '', $file->getURI());
+            $path= str_replace($cwd->getURI(), '', realpath($file->getURI()));
             Console::writeLinef("\r\e[0K> %s: \e[33m%.2f kB\e[0m", $path, $file->size() / 1024);
           }
         }
       }
 
-      return self::success(sizeof($bundles), $timer->elapsedTime());
+      // Clean up previous versions of our bundles
+      if ($manifest) {
+        Console::writeLinef("\e[32mCleaning up previous versions\e[0m");
+        foreach ($manifest->removed() as $remove) {
+          $bundle= new Bundle($target, $remove);
+          $bundle->close();
+          foreach ($bundle->files() as $file) {
+            $path= str_replace($cwd->getURI(), '', realpath($file->getURI()));
+            $file->exists() && $file->unlink();
+            Console::writeLinef("\r\e[0K> %s: \e[33m(deleted)\e[0m", $path);
+          }
+        }
+        $manifest->save();
+      }
+
+      return self::success(sizeof($bundles), isset($manifest), $timer->elapsedTime());
     } catch (Throwable $t) {
       return self::error(8, $t->toString());
     }

--- a/src/main/php/xp/frontend/Fetch.class.php
+++ b/src/main/php/xp/frontend/Fetch.class.php
@@ -57,7 +57,7 @@ class Fetch {
     if (200 === $status) {
       $stored->seek(0);
       $stored->truncate($r->header('Content-Length')[0] ?? 0);
-      $stored->writeLine($r->header('ETag')[0]);
+      $stored->writeLine($r->header('ETag')[0] ?? '');
       return new Download($uri, new Transfer($r->in(), $stored->out()), $this->progress);
     } else if (304 === $status) {
       return new Cached($uri, $stored->in(), true, $this->progress);

--- a/src/main/php/xp/frontend/Files.class.php
+++ b/src/main/php/xp/frontend/Files.class.php
@@ -1,0 +1,25 @@
+<?php namespace xp\frontend;
+
+use io\streams\InputStream;
+use io\{File, Folder};
+
+abstract class Files {
+  protected $target;
+
+  /** @param string|io.Folder $target */
+  public function __construct($target) {
+    $this->target= $target instanceof Folder ? $target : new Folder($target);
+    $this->target->exists() || $this->target->create();
+  }
+
+  public abstract function resolve($name, $type, $hash);
+
+  /**
+   * Store a given input stream under a given name and return file its
+   * contents were written to.
+   *
+   * @throws io.IOException
+   */
+  public abstract function store(InputStream $in, string $path): File;
+
+}

--- a/src/main/php/xp/frontend/Manifest.class.php
+++ b/src/main/php/xp/frontend/Manifest.class.php
@@ -1,0 +1,48 @@
+<?php namespace xp\frontend;
+
+use io\File;
+use text\json\{Json, FileInput, FileOutput};
+
+class Manifest {
+  private $file;
+  private $in;
+  private $out= [];
+
+  /** @param string|io.Path|io.File $file */
+  public function __construct($file) {
+    $this->file= $file instanceof File ? $file : new File($file);
+    $this->in= $this->file->exists() ? Json::read(new FileInput($this->file)) : [];
+  }
+
+  /** @return io.File */
+  public function file() { return $this->file; }
+
+  /**
+   * Associate compound name with resolved name
+   *
+   * @param  string $compound
+   * @param  string $resolved
+   * @return void
+   */
+  public function associate($compound, $resolved) {
+    $this->out[$compound]= $resolved;
+  }
+
+  /**
+   * Returns all compound and resolved names removed during upgrading
+   *
+   * @return [:string] 
+   */
+  public function removed() {
+    return array_diff($this->in, $this->out);
+  }
+
+  /**
+   * Save this manifest
+   *
+   * @return void
+   */
+  public function save() {
+    Json::write($this->out, new FileOutput($this->file));
+  }
+}

--- a/src/main/php/xp/frontend/Manifest.class.php
+++ b/src/main/php/xp/frontend/Manifest.class.php
@@ -22,10 +22,11 @@ class Manifest {
    *
    * @param  string $compound
    * @param  string $resolved
-   * @return void
+   * @return string
    */
   public function associate($compound, $resolved) {
     $this->out[$compound]= $resolved;
+    return $resolved;
   }
 
   /**

--- a/src/main/php/xp/frontend/ProcessStylesheet.class.php
+++ b/src/main/php/xp/frontend/ProcessStylesheet.class.php
@@ -1,9 +1,16 @@
 <?php namespace xp\frontend;
 
 use io\streams\{Streams, InputStream};
+use io\{File, Folder};
 use util\URI;
 
 class ProcessStylesheet {
+  private $files;
+
+  /** @param xp.frontend.Files */
+  public function __construct($files) {
+    $this->files= $files;
+  }
 
   public function process(Result $result, InputStream $stream, URI $uri= null) {
     $bytes= Streams::readAll($stream);
@@ -12,9 +19,15 @@ class ProcessStylesheet {
     // revalidate all dependencies, instead preferring the cached copy.
     preg_match_all('/url\(([^)]+)\)/', $bytes, $resources, PREG_SET_ORDER);
     foreach ($resources as $resource) {
-      $uri= new URI($resource[1]);
+      $uri= new URI(trim($resource[1], '"\''));
       if ($uri->isRelative()) {
-        $result->fetch($stream->origin->resolve($uri), !$stream->cached(), $uri);
+        $file= $this->files->store(
+          $result->fetch($stream->origin->resolve($uri), !$stream->cached(), $uri),
+          $uri->path()
+        );
+
+        // Update CSS with stored file's filename
+        $bytes= str_replace($resource[0], 'url('.$file->filename.')', $bytes);
       }
     }
 

--- a/src/main/php/xp/frontend/Result.class.php
+++ b/src/main/php/xp/frontend/Result.class.php
@@ -3,8 +3,11 @@
 use util\cmd\Console;
 
 class Result {
+  const HASH = 'sha1';
+
   private $cdn, $handlers;
   private $sources= [];
+  private $hashes= [];
 
   public function __construct(CDN $cdn, array $handlers) {
     $this->cdn= $cdn;
@@ -35,10 +38,12 @@ class Result {
 
   public function prefix($type, $bytes) {
     $this->sources[$type][0][]= $bytes;
+    hash_update($this->hashes[$type] ?? $this->hashes[$type]= hash_init(self::HASH), $bytes);
   }
 
   public function concat($type, $bytes) {
     $this->sources[$type][1][]= $bytes;
+    hash_update($this->hashes[$type] ?? $this->hashes[$type]= hash_init(self::HASH), $bytes);
   }
 
   /**
@@ -48,7 +53,7 @@ class Result {
    */
   public function sources() {
     foreach ($this->sources as $type => $list) {
-      yield $type => new Source($list);
+      yield $type => new Source($list, hash_final($this->hashes[$type]));
     }
   }
 }

--- a/src/main/php/xp/frontend/Result.class.php
+++ b/src/main/php/xp/frontend/Result.class.php
@@ -21,19 +21,16 @@ class Result {
    */
   public function include(Dependency $dependency) {
     foreach ($dependency->files as $file) {
-      $this->fetch($this->cdn->locate($dependency->library, $dependency->version, $file));
+      $uri= $this->cdn->locate($dependency->library, $dependency->version, $file);
+      $path= $uri->path();
+      $handler= $this->handlers[substr($path, strrpos($path, '.') + 1)] ?? $this->handlers['*'];
+      $handler->process($this, $this->fetch($uri), $uri);
     }
   }
 
   public function fetch($uri, $revalidate= true, $location= null) {
-    $path= $uri->path();
-    $type= substr($path, strrpos($path, '.') + 1);
-
-    Console::writef("\r\e[0K> \e[34m%s\e[0m ", $location ? '.../'.$location : $uri);
-    $stream= $this->cdn->fetch($uri, $revalidate);
-
-    $handler= $this->handlers[$type] ?? $this->handlers['*'];
-    $handler->process($this, $stream, $location);
+    Console::writef("\r\e[0K> \e[34m%s\e[0m ", $location ? '…/'.$location : $uri);
+    return $this->cdn->fetch($uri, $revalidate);
   }
 
   public function prefix($type, $bytes) {

--- a/src/main/php/xp/frontend/Source.class.php
+++ b/src/main/php/xp/frontend/Source.class.php
@@ -5,10 +5,12 @@ use lang\Closeable;
 
 class Source implements Closeable {
   private $list;
+  public $hash;
 
   /** Creates a new source */
-  public function __construct(array $list) {
+  public function __construct(array $list, string $hash) {
     $this->list= $list;
+    $this->hash= $hash;
   }
 
   /** Transfers this source to an output stream */

--- a/src/main/php/xp/frontend/StoreFile.class.php
+++ b/src/main/php/xp/frontend/StoreFile.class.php
@@ -1,24 +1,17 @@
 <?php namespace xp\frontend;
 
-use io\streams\{StreamTransfer, InputStream};
-use io\{File, Folder};
+use io\streams\InputStream;
 use util\URI;
 
 class StoreFile {
-  private $target;
+  private $files;
 
-  /** @param string|io.Folder $target */
-  public function __construct($target) {
-    $this->target= $target instanceof Folder ? $target : new Folder($target);
+  /** @param xp.frontend.Files */
+  public function __construct($files) {
+    $this->files= $files;
   }
 
   public function process(Result $result, InputStream $stream, URI $uri= null) {
-    $t= new File($this->target, $uri->path());
-    $f= new Folder($t->getPath());
-    $f->exists() || $f->create();
-
-    with (new StreamTransfer($stream, $t->out()), function($self) {
-      $self->transferAll();
-    });
+    $this->files->store($stream, $uri->path());
   }
 }

--- a/src/main/php/xp/frontend/UsingFilenames.class.php
+++ b/src/main/php/xp/frontend/UsingFilenames.class.php
@@ -1,0 +1,32 @@
+<?php namespace xp\frontend;
+
+use io\File;
+use io\streams\InputStream;
+
+/** Stores assets and dependencies by their original filenames */
+class UsingFilenames extends Files {
+
+  public function resolve($name, $type, $hash) {
+    return $name.'.'.$type;
+  }
+
+  /**
+   * Store a given input stream under a given name and return file its
+   * contents were written to.
+   *
+   * @throws io.IOException
+   */
+  public function store(InputStream $in, string $path): File {
+    $out= new File($this->target, basename($path));
+    $out->open(File::WRITE);
+    try {
+      while ($in->available()) {
+        $out->write($in->read());
+      }
+      return $out;
+    } finally {
+      $in->close();
+      $out->close();
+    }
+  }
+}

--- a/src/main/php/xp/frontend/WithFingerprints.class.php
+++ b/src/main/php/xp/frontend/WithFingerprints.class.php
@@ -1,0 +1,59 @@
+<?php namespace xp\frontend;
+
+use io\File;
+use io\streams\InputStream;
+
+/** Stores assets and dependencies by with fingerprints in their filenames */
+class WithFingerprints extends Files {
+  const HASH = 'sha1';
+  private $manifest;
+
+  /**
+   * Creates a new files implementation
+   *
+   * @param string|io.Folder $target
+   * @param xp.frontend.Manifest $manifest
+   */
+  public function __construct($target, $manifest) {
+    parent::__construct($target);
+    $this->manifest= $manifest;
+  }
+
+  public function resolve($name, $type, $hash) {
+    return $this->manifest->associate(
+      $name.'.'.$type,
+      $name.'.'.substr($hash, 0, 7).'.'.$type
+    );
+  }
+
+  /**
+   * Store a given input stream under a given name and return file its
+   * contents were written to.
+   *
+   * @throws io.IOException
+   */
+  public function store(InputStream $in, string $path): File {
+
+    // Store file temporarily and calculate a checksum while writing to it
+    $out= new File(tempnam($this->target->getURI(), self::class));
+    $out->open(File::WRITE);
+    try {
+      $ctx= hash_init(self::HASH);
+      while ($in->available()) {
+        $chunk= $in->read();
+        hash_update($ctx, $chunk);
+        $out->write($chunk);
+      }
+      $hash= hash_final($ctx);
+    } finally {
+      $in->close();
+      $out->close();
+    }
+
+    // Rename the file to [filename].[contenthash].[extension]
+    $file= basename($path);
+    $type= substr($file, strrpos($file, '.') + 1);
+    $out->move($this->target->getURI().$this->resolve(basename($file, '.'.$type), $type, $hash));
+    return $out;
+  }
+}

--- a/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\frontend\unittest;
 
+use io\File;
 use lang\FormatException;
 use text\json\StringInput;
 use unittest\{Test, Values, Expect, TestCase};
@@ -52,6 +53,14 @@ class AssetsManifestTest extends TestCase {
     $this->assertEquals(
       'max-age=31536000, immutable',
       $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('vendor.f6cad2a.css.gz')
+    );
+  }
+
+  #[Test]
+  public function immutable_file() {
+    $this->assertEquals(
+      'max-age=31536000, immutable',
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable(new File('vendor.f6cad2a.css'))
     );
   }
 

--- a/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
@@ -1,0 +1,64 @@
+<?php namespace web\frontend\unittest;
+
+use lang\FormatException;
+use text\json\StringInput;
+use unittest\{Test, Values, Expect, TestCase};
+use web\frontend\AssetsManifest;
+
+class AssetsManifestTest extends TestCase {
+
+  /** @return iterable */
+  private function inputs() {
+    yield ['{}'];
+    yield ['{"vendor.css" : "vendor.f6cad2a.css"}'];
+    yield ['{"vendor.css" : "vendor.f6cad2a.css", "vendor.js" : "vendor.7b1f7cb.js"}'];
+  }
+
+  /**
+   * Creates a new fixture
+   *
+   * @param  string $input
+   * @return web.frontend.AssetsManifest
+   */
+  private function fixture($input) {
+    return new AssetsManifest(new StringInput($input));
+  }
+
+  #[Test]
+  public function can_create() {
+    $this->fixture('{}');
+  }
+
+  #[Test, Expect(class: FormatException::class, withMessage: '/Unexpected token/')]
+  public function cannot_create_with_malformed() {
+    $this->fixture('not.json');
+  }
+
+  #[Test, Values('inputs')]
+  public function assets($input) {
+    $this->assertEquals(json_decode($input, true), $this->fixture($input)->assets);
+  }
+
+  #[Test]
+  public function immutable_asset() {
+    $this->assertEquals(
+      'max-age=31536000, immutable',
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('vendor.f6cad2a.css')
+    );
+  }
+
+  #[Test]
+  public function immutable_gzipped_asset() {
+    $this->assertEquals(
+      'max-age=31536000, immutable',
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('vendor.f6cad2a.css.gz')
+    );
+  }
+
+  #[Test]
+  public function regular_asset() {
+    $this->assertNull(
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('style.css')
+    );
+  }
+}


### PR DESCRIPTION
Implements #15 using assets manifests to keep this bundling ecosystem compatible with Webpack.

* [x] Calculate content hash of JS and CSS files
* [x] Fingerprint dependencies of CSS files and rewrite the CSS accordingly
* [x] Create asset manifest with all of the above

## Usage

To include fingerprints in the asset filenames, you must invoke the *bundle*  command with the `-m` option. This will include a fingerprint in the filenames:

![image](https://user-images.githubusercontent.com/696742/113565781-d9ee1e80-960b-11eb-936c-6bc474638356.png)

...and generate a manifest, mapping all bundles' and all their dependencies' file names to the fingerprinted versions:

```bash
$ cat src/main/webapp/static/manifest.json | json_pp
{
   "vendor.js" : "vendor.7b1f7cb.js",
   "vendor.css" : "vendor.f6cad2a.css",
   "editor.css" : "editor.28c52e0.css",
   "editor.js" : "editor.870c123.js",
   "icons.svg" : "icons.dd83d26.svg"
}
```

*Like GIT, we use the first 7 characters of an SHA1 checksum for fingerprinting*.

This manifest needs to be passed to the frontend:

```diff
diff --git a/src/main/php/com/example/skills/App.php b/src/main/php/com/example/skills/App.php
index 6fc6ac5..d62593d 100755
--- a/src/main/php/com/example/skills/App.php
+++ b/src/main/php/com/example/skills/App.php
@@ -3,7 +3,7 @@
 use inject\{Injector, Bindings};
 use security\credentials\{Credentials, FromEnvironment, FromFile};
 use web\frontend\helpers\Dates;
-use web\frontend\{Frontend, HandlersIn, AssetsFrom, Handlebars};
+use web\frontend\{Frontend, HandlersIn, AssetsFrom, AssetsManifest, Handlebars};
 use web\rest\{RestApi, ResourcesIn};
 use web\session\{Sessions, InFileSystem, Cookies};
 use web\{Application, Filters};
@@ -29,8 +29,9 @@ class App extends Application {
     $inject->bind(Sessions::class, $sessions);
 
     $auth= $inject->get(Office365Integration::class)->using($sessions);
-    $assets= new AssetsFrom($this->environment->path('src/main/webapp'))->with([
-      'Cache-Control' => 'max-age=2419200, must-revalidate'
+    $manifest= new AssetsManifest($this->environment->path('src/main/webapp/static/manifest.json'));
+    $assets= new AssetsFrom($this->environment->path('src/main/webapp'))->with(fn($file) => [
+      'Cache-Control' => $manifest->immutable($file) ?? 'max-age=2419200, must-revalidate'
     ]);
     return [
       '/favicon.ico' => $assets,
@@ -47,7 +48,7 @@ class App extends Application {
           new Translations($this->environment->path('src/main/handlebars/texts.csv')),
           new RenderMarkdown(),
         ),
-        '/'
+        ['manifest' => $manifest]
       ))
     ];
   }

```

Now, you can access the access the real filenames of your assets in your templates, for example:

```diff
-    <script src="/static/vendor.js"></script>
+    <script src="/static/{{lookup manifest.assets 'vendor.js'}}"></script>
```

This will yield `<script src="/static/vendor.7b1f7cb.js"></script>` in the output document.

## Cleaning

When using a manifest, we keep track of all files. To ensure our output directory only contains those that are really referenced, the XP bundler will make use of this and delete any previous versions when it runs:

![image](https://user-images.githubusercontent.com/696742/113567087-394d2e00-960e-11eb-9e70-05768cadf6c0.png)
