### PR TITLE
Extend AssetsFrom handler from web.handlers.FilesFrom

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-forge/web": "^2.0 | ^1.0",
+    "xp-forge/web": "dev-feature/filehandler-headers as 2.9.0",
     "xp-forge/json": "^4.0",
     "php": ">=7.0.0"
   },

--- a/src/main/php/web/frontend/AssetsManifest.class.php
+++ b/src/main/php/web/frontend/AssetsManifest.class.php
@@ -2,6 +2,7 @@
 
 use io\File;
 use text\json\{Json, Input, FileInput};
+use util\URI;
 
 /**
  * Assets manifest 
@@ -21,14 +22,18 @@ class AssetsManifest {
    * Returns an immutable cache header if a file is contained in this
    * manifest.
    *
-   * @param  io.Path|io.File|string $file
+   * @param  io.Path|io.File|util.URI|string $file
    * @return ?string
    */
-  public function immutable($file) {
-    $compare= $file instanceof File ? $file->filename : (string)$file;
-    foreach ($this->assets as $resolved) {
-      if (0 === strpos($compare, $resolved)) return 'max-age=31536000, immutable';
+  public function immutable($path) {
+    if ($path instanceof URI) {
+      $compare= basename($path->path());
+    } else if ($path instanceof File) {
+      $compare= $path->filename;
+    } else {
+      $compare= (string)$path;
     }
-    return null;
+
+    return in_array($compare, $this->assets) ? 'max-age=31536000, immutable' : null;
   }
 }

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -40,8 +40,12 @@ class AssetsFromTest {
     $req= new Request(new TestInput('GET', $path, $headers));
     $res= new Response(new TestOutput());
 
-    $assets->handle($req, $res);
-    return $res;
+    try {
+      foreach ($assets->handle($req, $res) ?? [] as $_) { }
+      return $res;
+    } finally {
+      $res->end();
+    }
   }
 
   /**
@@ -60,14 +64,14 @@ class AssetsFromTest {
   private function headers() {
     yield [['Cache-Control' => 'no-cache']];
 
-    yield [function($file) {
+    yield [function($uri, $file, $mime) {
       if (strstr($file->filename, 'fixture')) {
         yield 'Cache-Control' => 'no-cache';
       }
     }];
 
     yield [new class() {
-      public function __invoke($file) {
+      public function __invoke($uri, $file, $mime) {
         yield 'Cache-Control' => 'no-cache';
       }
     }];

--- a/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsManifestTest.class.php
@@ -4,6 +4,7 @@ use io\File;
 use lang\FormatException;
 use text\json\StringInput;
 use unittest\{Test, Values, Expect, TestCase};
+use util\URI;
 use web\frontend\AssetsManifest;
 
 class AssetsManifestTest extends TestCase {
@@ -49,14 +50,6 @@ class AssetsManifestTest extends TestCase {
   }
 
   #[Test]
-  public function immutable_gzipped_asset() {
-    $this->assertEquals(
-      'max-age=31536000, immutable',
-      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('vendor.f6cad2a.css.gz')
-    );
-  }
-
-  #[Test]
   public function immutable_file() {
     $this->assertEquals(
       'max-age=31536000, immutable',
@@ -65,9 +58,24 @@ class AssetsManifestTest extends TestCase {
   }
 
   #[Test]
+  public function immutable_uri() {
+    $this->assertEquals(
+      'max-age=31536000, immutable',
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable(new URI('/assets/vendor.f6cad2a.css'))
+    );
+  }
+
+  #[Test]
   public function regular_asset() {
     $this->assertNull(
       $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('style.css')
+    );
+  }
+
+  #[Test]
+  public function regular_gzipped_asset() {
+    $this->assertNull(
+      $this->fixture('{"vendor.css" : "vendor.f6cad2a.css"}')->immutable('vendor.f6cad2a.css.gz')
     );
   }
 }


### PR DESCRIPTION
This enables asynchronous handling as well as being able to use extended headers, see https://github.com/xp-forge/web/pull/74#issuecomment-817117750

⚠️ This pull request will bump the dependency on xp-forge/web to ^2.9 (and drop support for version 1). Because BC is broken anyway, the with() function is changed at the same time in backwards-incompatible way! However, because we also widen the parameter types for immutable(), code such as the following will continue to work:

```php
$assets= new AssetsFrom($this->environment->path('src/main/webapp'))->with(fn($path) => [
  'Cache-Control' => $manifest->immutable($path) ?? 'max-age=2419200, must-revalidate'
]);
```

*Previously, $path was a File instance, now it's a URI...*