### PR TITLE
If brotli extension is available, also compress to .br files

### DIFF
--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -14,7 +14,7 @@ use web\handler\FilesFrom;
  * @see  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
  */
 class AssetsFrom extends FilesFrom {
-  const PREFERENCE= ['br', 'bzip2', 'gzip'];
+  const PREFERENCE= ['br', 'bzip2', 'gzip', 'deflate'];
   const ENCODINGS= [
     'br'       => '.br',
     'bzip2'    => '.bz2',

--- a/src/main/php/xp/frontend/BrCompressingOutputStream.class.php
+++ b/src/main/php/xp/frontend/BrCompressingOutputStream.class.php
@@ -1,0 +1,64 @@
+<?php namespace xp\frontend;
+
+use io\streams\OutputStream;
+use lang\IllegalArgumentException;
+
+/**
+ * Brotli output stream
+ *
+ * @ext  brotli
+ * @test web.frontend.unittest.bundler.BrCompressingOutputStreamTest
+ * @see  https://github.com/kjdev/php-ext-brotli
+ */
+class BrCompressingOutputStream implements OutputStream {
+
+  /**
+   * Creates a new compressing output stream
+   *
+   * @param  io.streams.OutputStream $out The stream to write to
+   * @param  int $level
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(OutputStream $out, $level= BROTLI_COMPRESS_LEVEL_MAX) {
+    if ($level < BROTLI_COMPRESS_LEVEL_MIN || $level > BROTLI_COMPRESS_LEVEL_MAX) {
+      throw new IllegalArgumentException('Level must be between '.BROTLI_COMPRESS_LEVEL_MIN.' and '.BROTLI_COMPRESS_LEVEL_MAX);
+    }
+
+    $this->out= $out;
+    $this->handle= brotli_compress_init($level);
+  }
+
+  /**
+   * Write a string
+   *
+   * @param  var $arg
+   * @return void
+   */
+  public function write($arg) {
+    $this->out->write(brotli_compress_add($this->handle, $arg, BROTLI_PROCESS));
+  }
+
+  /**
+   * Flush this buffer
+   *
+   * @return void
+   */
+  public function flush() {
+    $this->out->flush();
+  }
+
+  /**
+   * Closes this object. May be called more than once, which may
+   * not fail - that is, if the object is already closed, this 
+   * method should have no effect.
+   *
+   * @throws lang.XPException
+   */
+  public function close() {
+    if ($this->handle) {
+      $this->out->write(brotli_compress_add($this->handle, '', BROTLI_FINISH));
+      $this->handle= null;
+    }
+    $this->out->close();
+  }
+}

--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -4,12 +4,13 @@ use io\File;
 use io\streams\{OutputStream, GzCompressingOutputStream};
 
 class Bundle implements OutputStream {
-  private static $zlib;
+  private static $zlib, $brotli;
   private $files= [];
   private $output= [];
 
   static function __static() {
     self::$zlib= extension_loaded('zlib');
+    self::$brotli= extension_loaded('brotli');
   }
 
   /**
@@ -22,6 +23,9 @@ class Bundle implements OutputStream {
     $this->output[]= $this->output(new File($path, $name));
     if (self::$zlib) {
       $this->output[]= new GzCompressingOutputStream($this->output(new File($path, $name.'.gz')), 9);
+    }
+    if (self::$brotli) {
+      $this->output[]= new BrCompressingOutputStream($this->output(new File($path, $name.'.br')), 11); 
     }
   }
 

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -90,7 +90,7 @@ class AssetsFromTest {
   #[Test]
   public function typical_ua_header_negotiated() {
     Assert::equals(
-      ['br' => 1.03, 'gzip' => 1.01, 'deflate' => 1.0, '*' => 0.01],
+      ['br' => 1.04, 'gzip' => 1.02, 'deflate' => 1.01, '*' => 0.01],
       (new AssetsFrom('.'))->negotiate('gzip, deflate, br')
     );
   }
@@ -114,7 +114,7 @@ class AssetsFromTest {
   #[Test]
   public function header_with_qvalues_accepted() {
     Assert::equals(
-      ['deflate' => 1.0, 'gzip' => 1.0, '*' => 0.5],
+      ['deflate' => 1.01, 'gzip' => 1.0, '*' => 0.5],
       (new AssetsFrom('.'))->negotiate('deflate, gzip;q=1.0, *;q=0.5')
     );
   }

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -88,26 +88,34 @@ class AssetsFromTest {
   }
 
   #[Test]
-  public function typical_ua_header_accepted() {
+  public function typical_ua_header_negotiated() {
     Assert::equals(
-      ['gzip' => 0.99, 'deflate' => 0.98, 'br' => 0.97, '*' => 0.01],
-      AssetsFrom::accepted('gzip, deflate, br')
+      ['br' => 1.03, 'gzip' => 1.01, 'deflate' => 1.0, '*' => 0.01],
+      (new AssetsFrom('.'))->negotiate('gzip, deflate, br')
+    );
+  }
+
+  #[Test]
+  public function typical_ua_header_preferring_gzip() {
+    Assert::equals(
+      ['gzip' => 1.02, 'br' => 1.01, 'deflate' => 1.0, '*' => 0.01],
+      (new AssetsFrom('.'))->preferring(['gzip', 'br'])->negotiate('gzip, deflate, br')
     );
   }
 
   #[Test]
   public function identity_accepted() {
     Assert::equals(
-      ['identity' => 0.99, '*' => 0.01],
-      AssetsFrom::accepted('identity')
+      ['identity' => 1.0, '*' => 0.01],
+      (new AssetsFrom('.'))->negotiate('identity')
     );
   }
 
   #[Test]
   public function header_with_qvalues_accepted() {
     Assert::equals(
-      ['gzip' => 1.0, 'deflate' => 0.99, '*' => 0.5],
-      AssetsFrom::accepted('deflate, gzip;q=1.0, *;q=0.5')
+      ['deflate' => 1.0, 'gzip' => 1.0, '*' => 0.5],
+      (new AssetsFrom('.'))->negotiate('deflate, gzip;q=1.0, *;q=0.5')
     );
   }
 
@@ -159,7 +167,7 @@ class AssetsFromTest {
   }
 
   #[Test, Values([['fixture.css.gz', 'gzip'], ['fixture.css.br', 'br'], ['fixture.css.dfl', 'deflate'], ['fixture.css.bz2', 'bzip2']])]
-  public function serves_compressed_when_gz_file_present($file, $encoding) {
+  public function serves_compressed_when_file_present($file, $encoding) {
     $files= [$file => self::COMPRESSED];
     $res= $this->serve(new AssetsFrom($this->folderWith($files)), '/fixture.css', [
       'Accept-Encoding' => 'gzip, bzip2, deflate, br'
@@ -185,10 +193,23 @@ class AssetsFromTest {
   }
 
   #[Test]
+  public function prefers_brotli_compressed_when_gz_and_br_files_present() {
+    $files= ['fixture.css' => self::CONTENTS, 'fixture.css.gz' => self::COMPRESSED, 'fixture.css.br' => self::COMPRESSED];
+    $res= $this->serve(new AssetsFrom($this->folderWith($files)), '/fixture.css', [
+      'Accept-Encoding' => 'gzip, br'
+    ]);
+
+    Assert::equals(200, $res->status());
+    Assert::equals('text/css', $res->headers()['Content-Type']);
+    Assert::equals('br', $res->headers()['Content-Encoding']);
+    $this->assertFile($files['fixture.css.br'], $res);
+  }
+
+  #[Test]
   public function prefers_uncompressed_for_identity() {
     $files= ['fixture.css' => self::CONTENTS, 'fixture.css.gz' => self::COMPRESSED];
     $res= $this->serve(new AssetsFrom($this->folderWith($files)), '/fixture.css', [
-      'Accept-Encoding' => 'identity;q=1.0, gzip'
+      'Accept-Encoding' => 'identity;q=1.0, gzip;q=0.9'
     ]);
 
     Assert::equals(200, $res->status());

--- a/src/test/php/web/frontend/unittest/bundler/BrCompressingOutputStreamTest.class.php
+++ b/src/test/php/web/frontend/unittest/bundler/BrCompressingOutputStreamTest.class.php
@@ -1,0 +1,39 @@
+<?php namespace web\frontend\unittest\bundler;
+
+use io\streams\MemoryOutputStream;
+use lang\IllegalArgumentException;
+use unittest\{Assert, Before, Test, Values};
+use xp\frontend\BrCompressingOutputStream;
+
+class BrCompressingOutputStreamTest {
+
+  #[Before]
+  public function verify() {
+    if (!extension_loaded('brotli')) {
+      throw new PrerequisitesNotMetError('Brotli extension missing');
+    }
+  }
+
+  #[Test]
+  public function can_create() {
+    new BrCompressingOutputStream(new MemoryOutputStream());
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function using_invalid_compression_level() {
+    new BrCompressingOutputStream(new MemoryOutputStream(), -1);
+  }
+
+  #[Test, Values([1, 6, 11])]
+  public function write($level) {
+    $out= new MemoryOutputStream();
+
+    $fixture= new BrCompressingOutputStream($out, $level);
+    $fixture->write('Hello');
+    $fixture->write(' ');
+    $fixture->write('World');
+    $fixture->close();
+
+    Assert::equals('Hello World', brotli_uncompress($out->bytes()));
+  }
+}


### PR DESCRIPTION
See https://github.com/xp-forge/frontend/issues/21#issuecomment-822652962

| File | Uncompressed | Gzip| Brotli | Delta |
| --- | ---------------- | --------- | ----- | ------ |
| vendor.7b1f7cb.js | 795.95 kB | 229.87 kB |  175.62 kB | 54.25 kB |
| vendor.4d33b13.css | 1330.04 kB | 154.79 kB | 115.12 kB | 39.67 kB |

When compressing both .gz and .br, runtime increased from 4.429 (*for only compressing with gzip*) to 10.893 seconds.