### PR TITLE
Exception handling API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ In real-life situations, you will not want to put all of your code into the `Hel
 
 ```bash
 @FileSystemCL<./src/main/php>
-package org.example.example.web {
+package org.example.web {
 
-  public class org.example.example.web.Home
-  public class org.example.example.web.User
-  public class org.example.example.web.Group
+  public class org.example.web.Home
+  public class org.example.web.User
+  public class org.example.web.Group
 }
 ```
 
@@ -89,7 +89,7 @@ Then use the delegation API provided by the `HandlersIn` class:
 use web\frontend\{Frontend, HandlersIn};
 
 // ...inside the routes() method, as seen above:
-new Frontend(new HandlersIn('org.example.example.web'), $templates);
+new Frontend(new HandlersIn('org.example.web'), $templates);
 ```
 
 ## Handling routes and methods
@@ -220,6 +220,24 @@ $ xp bundle -m src/main/webapp/manifest.json src/main/webapp/static
 ```
 
 This will create *vendor.[fingerprint].js* and *vendor.[fingerprint].css* files as well as compressed versions (*if the zlib and [brotli](https://github.com/kjdev/php-ext-brotli) PHP extensions are available*) and the assets manifest, which maps the file names without fingerprints to those with.
+
+## Error handling
+
+By default, errors and exceptions will yield in a minimalistic error page with the corresponding error code (*defaulting to 500 Internal Server Error*) shown. Exceptions can be handled by a closure, a status code or by default, and decide to return a view of their own. This view is loaded from the *errors/* subfolder and passed a context of `['cause' => $exception]`.
+
+```php
+use web\frontend\{HandlersIn, FrontendIn, Exceptions};
+use org\example\{InvalidOrder, LinkExpired};
+use lang\Throwable;
+
+$frontend= (new Frontend(new HandlersIn('org.example.web'), $templates))
+  ->handling((new Exceptions())
+    ->catch(InvalidOrder::class, fn($e) => View::error(503, 'invalid-order')),
+    ->catch(LinkExpired::class, 404) // uses template "error/404"
+    ->catch(Throwable::class)        // catch-all, errors/{status} for web.Error, errors/500 for others
+  )
+;
+```
 
 ## Performance
 

--- a/src/main/php/web/frontend/Delegate.class.php
+++ b/src/main/php/web/frontend/Delegate.class.php
@@ -61,8 +61,7 @@ class Delegate {
           if ($param->isOptional()) {
             $default= $param->getDefaultValue();
             $this->parameters[$name]= function($req, $name) use($source, $default) {
-              $r= $source($req, $name);
-              return null === $r ? $default : $r;
+              return $source($req, $name) ?? $default;
             };
           } else {
             $this->parameters[$name]= $source;
@@ -79,17 +78,16 @@ class Delegate {
    * Invokes this delegate
    *
    * @param  var[] $args
-   * @param  web.frontend.Templates $templates
    * @return web.frontend.View
    * @throws lang.reflect.TargetInvocationException
    */
-  public function invoke($args, $templates) {
+  public function invoke($args) {
     $result= $this->method->invoke($this->instance, $args);
     if ($result instanceof View) {
-      $result->template || $result->template= $this->group();
-      return $result->using($templates);
+      $result->template ?? $result->template= $this->group();
+      return $result;
     } else {
-      return View::named($this->group())->with($result)->using($templates);
+      return View::named($this->group())->with($result);
     }
   }
 }

--- a/src/main/php/web/frontend/Delegates.class.php
+++ b/src/main/php/web/frontend/Delegates.class.php
@@ -37,11 +37,12 @@ class Delegates {
   }
 
   /**
-   * Returns target for a given HTTP verb and path
+   * Returns target delegate and matches for a given HTTP verb and path, or
+   * NULL if not such target exists
    *
    * @param  string $verb
    * @param  string $path
-   * @return web.frontend.Delegate or NULL
+   * @return ?var[]
    */
   public function target($verb, $path) {
     $match= $verb.$path;

--- a/src/main/php/web/frontend/Errors.class.php
+++ b/src/main/php/web/frontend/Errors.class.php
@@ -1,0 +1,13 @@
+<?php namespace web\frontend;
+
+interface Errors {
+
+  /**
+   * Handles errors
+   *
+   * @param  lang.Throwable $cause
+   * @return web.frontend.Target
+   * @throws web.Error
+   */
+  public function handle($cause);
+}

--- a/src/main/php/web/frontend/Exceptions.class.php
+++ b/src/main/php/web/frontend/Exceptions.class.php
@@ -10,13 +10,13 @@ use web\Error;
  * $handler= new Exceptions();
  *
  * // Use errors/{status} for web.Error instances, errors/500 for others
- * $handler->mapping(Throwable::class);
+ * $handler->catch(Throwable::class);
  *
  * // Always use errors/503 for all SQLExceptions
- * $handler->mapping(SQLException::class, 503);
+ * $handler->catch(SQLException::class, 503);
  *
  * // Supply a handler function returning a view
- * $handler->mapping(InvalidOrder::class, fn($e) => View::error(404, 'invalid-order'));
+ * $handler->catch(InvalidOrder::class, fn($e) => View::error(404, 'invalid-order'));
  * ```
  *
  * @test  web.frontend.unittest.ExceptionsTest
@@ -31,7 +31,7 @@ class Exceptions implements Errors {
    * @param  ?int|callable $handler
    * @return self
    */
-  public function mapping($type, $handler= null) {
+  public function catch($type, $handler= null) {
     if (null === $handler) {
       $this->mapping[$type]= function($cause) { return View::error($cause instanceof Error ? $cause->status() : 500); };
     } else if (is_int($handler)) {

--- a/src/main/php/web/frontend/Exceptions.class.php
+++ b/src/main/php/web/frontend/Exceptions.class.php
@@ -1,0 +1,62 @@
+<?php namespace web\frontend;
+
+use lang\IllegalArgumentException;
+use web\Error;
+
+/**
+ * Maps exceptions to views
+ *
+ * ```php
+ * $handler= new Exceptions();
+ *
+ * // Use errors/{status} for web.Error instances, errors/500 for others
+ * $handler->mapping(Throwable::class);
+ *
+ * // Always use errors/503 for all SQLExceptions
+ * $handler->mapping(SQLException::class, 503);
+ *
+ * // Supply a handler function returning a view
+ * $handler->mapping(InvalidOrder::class, fn($e) => View::error(404, 'invalid-order'));
+ * ```
+ *
+ * @test  web.frontend.unittest.ExceptionsTest
+ */
+class Exceptions implements Errors {
+  private $mapping= [];
+
+  /**
+   * Maps an exception type to a handler
+   *
+   * @param  string $type
+   * @param  ?int|callable $handler
+   * @return self
+   */
+  public function mapping($type, $handler= null) {
+    if (null === $handler) {
+      $this->mapping[$type]= function($cause) { return View::error($cause instanceof Error ? $cause->status() : 500); };
+    } else if (is_int($handler)) {
+      $this->mapping[$type]= function() use($handler) { return View::error($handler); };
+    } else if (is_callable($handler)) {
+      $this->mapping[$type]= $handler;
+    } else {
+      throw new IllegalArgumentException('Expected NULL, an integer or a callable');
+    }
+    return $this;
+  }
+
+  /**
+   * Handles errors
+   *
+   * @param  lang.Throwable $cause
+   * @return web.frontend.View
+   * @throws web.Error
+   */
+  public function handle($cause) {
+    foreach ($this->mapping as $type => $mapping) {
+      if ($cause instanceof $type) return $mapping($cause)->with(['cause' => $cause]);
+    }
+
+    // Unhanded, raise error and display default error page
+    throw $cause instanceof Error ? $cause : new Error(500, $cause->getMessage(), $cause);
+  }
+}

--- a/src/main/php/web/frontend/Exceptions.class.php
+++ b/src/main/php/web/frontend/Exceptions.class.php
@@ -53,7 +53,7 @@ class Exceptions implements Errors {
    */
   public function handle($cause) {
     foreach ($this->mapping as $type => $mapping) {
-      if ($cause instanceof $type) return $mapping($cause)->with(['cause' => $cause]);
+      if ($cause instanceof $type && ($view= $mapping($cause))) return $view->with(['cause' => $cause]);
     }
 
     // Unhanded, raise error and display default error page

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -11,8 +11,7 @@ use web\{Error, Handler};
  * @test  web.frontend.unittest.CSRFTokenTest
  */
 class Frontend implements Handler {
-  private $delegates, $templates;
-  private $errors= null;
+  private $delegates, $templates, $errors;
   public $globals;
 
   /**
@@ -21,11 +20,13 @@ class Frontend implements Handler {
    * @param  web.frontend.Delegates|object $arg
    * @param  web.frontend.Templates $templates
    * @param  [:var] $globals
+   * @param  ?web.frontend.Errors $handling
    */
-  public function __construct($arg, Templates $templates, $globals= []) {
+  public function __construct($arg, Templates $templates, $globals= [], Errors $handling= null) {
     $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->templates= $templates;
     $this->globals= is_string($globals) ? ['base' => rtrim($globals, '/')] : $globals;
+    $this->errors= $handling;
   }
 
   /** Overwrites error handler */

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -67,7 +67,7 @@ class Frontend implements Handler {
         $args[]= $matches[$name] ?? $source($req, $name);
       }
 
-      return $delegate->invoke($args, $this->templates);
+      return $delegate->invoke($args);
     } catch (TargetInvocationException $e) {
       return $this->errors()->handle($e->getCause());
     }
@@ -83,6 +83,6 @@ class Frontend implements Handler {
    */
   public function handle($req, $res) {
     $res->header('Server', 'XP/Frontend');
-    $this->view($req, $res)->transfer($req, $res, $this->globals);
+    $this->view($req, $res)->using($this->templates)->transfer($req, $res, $this->globals);
   }
 }

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -31,14 +31,14 @@ class Frontend implements Handler {
   public function handle($req, $res) {
     $res->header('Server', 'XP/Frontend');
 
-    $verb= strtolower($req->method());
-    if (null === ($target= $this->delegates->target($verb, $req->uri()->path()))) {
-      throw new Error(400, 'Method '.$req->method().' not supported by any delegate');
+    $method= strtolower($req->method());
+    if (null === ($target= $this->delegates->target($method, $req->uri()->path()))) {
+      throw new Error(404, 'Cannot route '.$req->method().' requests to '.$req->uri()->path());
     }
     list($delegate, $matches)= $target;
 
     // Verify CSRF token for anything which is not a GET or HEAD request
-    if (!in_array($verb, ['get', 'head']) && $req->value('token') !== $req->param('token')) {
+    if (!in_array($method, ['get', 'head']) && $req->value('token') !== $req->param('token')) {
       throw new Error(400, 'Missing CSRF token for '.$delegate->name());
     }
 

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -40,13 +40,13 @@ class Frontend implements Handler {
   }
 
   /**
-   * Determines target, handling errors while going along.
+   * Determines view to be displayed, handling errors while going along.
    *
    * @param  web.Request $req
    * @param  web.Response $res
-   * @return web.frontend.Target
+   * @return web.frontend.View
    */
-  private function target($req, $res) {
+  private function view($req, $res) {
     static $CSRF_EXEMPT= ['get' => true, 'head' => true];
 
     $method= strtolower($req->method());
@@ -82,7 +82,6 @@ class Frontend implements Handler {
    */
   public function handle($req, $res) {
     $res->header('Server', 'XP/Frontend');
-
-    $this->target($req, $res)->transfer($req, $res, $this->globals);
+    $this->view($req, $res)->transfer($req, $res, $this->globals);
   }
 }

--- a/src/main/php/web/frontend/RaiseErrors.class.php
+++ b/src/main/php/web/frontend/RaiseErrors.class.php
@@ -17,10 +17,6 @@ class RaiseErrors implements Errors {
    * @throws web.Error
    */
   public function handle($cause) {
-    if ($cause instanceof Error) {
-      throw $cause;
-    } else {
-      throw new Error(500, $cause->getMessage(), $cause);
-    }
+    throw $cause instanceof Error ? $cause : new Error(500, $cause->getMessage(), $cause);
   }
 }

--- a/src/main/php/web/frontend/RaiseErrors.class.php
+++ b/src/main/php/web/frontend/RaiseErrors.class.php
@@ -1,0 +1,26 @@
+<?php namespace web\frontend;
+
+use web\Error;
+
+/**
+ * Raises errors and causes builtin web error pages to be rendered.
+ *
+ * @see  https://github.com/xp-forge/web/issues/53
+ */
+class RaiseErrors implements Errors {
+
+  /**
+   * Handles errors
+   *
+   * @param  lang.Throwable $cause
+   * @return web.frontend.Target
+   * @throws web.Error
+   */
+  public function handle($cause) {
+    if ($cause instanceof Error) {
+      throw $cause;
+    } else {
+      throw new Error(500, $cause->getMessage(), $cause);
+    }
+  }
+}

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -113,7 +113,6 @@ class View {
    *
    * @param  web.Request $req
    * @param  web.Response $res
-   * @param  [:var] $globals
    * @return void
    */
   public function transfer($req, $res, $globals) {

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -13,7 +13,7 @@ class View {
   }
 
   /**
-   * Sets template to use.
+   * Sets template to use
    *
    * @param  string $template
    * @return self
@@ -33,6 +33,21 @@ class View {
     $self->status= 302;
     $self->headers['Location']= $url;
     $self->context= null;
+    return $self;
+  }
+
+  /**
+   * Creates an error view with a given status and template. The template
+   * will be named *errors/{template}* or *errors/{status}* if its name
+   * is omitted.
+   *
+   * @param  int $status
+   * @param  ?string $template
+   * @return self
+   */
+  public static function error(int $status, $template= null) {
+    $self= new self('errors/'.($template ?? $status));
+    $self->status= $status;
     return $self;
   }
 
@@ -66,7 +81,7 @@ class View {
    * @return self
    */
   public function with($context) {
-    $this->context= $context;
+    $this->context+= $context;
     return $this;
   }
 

--- a/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
+++ b/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
@@ -46,12 +46,12 @@ class CSRFTokenTest extends TestCase {
     $this->execute('GET', '/users');
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Missing CSRF token for .+Users::create/')]
+  #[Test, Expect(class: Error::class, withMessage: '/Incorrect CSRF token for .+Users::create/')]
   public function raises_error_when_missing() {
     $this->execute('POST', '/users', 'username=test');
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Missing CSRF token for .+Users::create/')]
+  #[Test, Expect(class: Error::class, withMessage: '/Incorrect CSRF token for .+Users::create/')]
   public function raises_error_when_incorrect() {
     $this->execute('POST', '/users', 'token=INCORRECT&username=test');
   }

--- a/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
+++ b/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
@@ -30,7 +30,7 @@ class CSRFTokenTest extends TestCase {
   private function execute($method, $uri, $payload= null) {
     $headers= $payload ? ['Content-Type' => 'application/x-www-form-urlencoded'] : [];
 
-    $req= new Request(new TestInput($method, $uri, $headers, $payload));
+    $req= new Request(new TestInput($method, $uri, $headers, (string)$payload));
     $res= new Response(new TestOutput());
 
     $this->fixture->handle($req->pass('token', self::TOKEN), $res);

--- a/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
@@ -25,7 +25,7 @@ class ExceptionsTest {
   #[Test, Expect(class: Error::class, withMessage: 'test')]
   public function callable_returning_null_will_raise() {
     (new Exceptions())
-      ->mapping(IllegalArgumentException::class, function($e) { return null; })
+      ->catch(IllegalArgumentException::class, function($e) { return null; })
       ->handle(new IllegalArgumentException('test'))
     ;
   }
@@ -33,7 +33,7 @@ class ExceptionsTest {
   #[Test]
   public function mapping_web_error_uses_its_statuscode() {
     $view= (new Exceptions())
-      ->mapping(Error::class)
+      ->catch(Error::class)
       ->handle(new Error(404, 'test'))
     ;
     Assert::equals([404, 'errors/404'], [$view->status, $view->template]);
@@ -42,7 +42,7 @@ class ExceptionsTest {
   #[Test]
   public function mapping_exception_uses_500_as_statuscode() {
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class)
+      ->catch(IllegalArgumentException::class)
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
@@ -51,7 +51,7 @@ class ExceptionsTest {
   #[Test]
   public function mapping_exception_to_statuscode() {
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class, 400)
+      ->catch(IllegalArgumentException::class, 400)
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([400, 'errors/400'], [$view->status, $view->template]);
@@ -60,7 +60,7 @@ class ExceptionsTest {
   #[Test]
   public function mapping_exception_to_callable() {
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class, function($e) { return View::error(400, 'validation'); })
+      ->catch(IllegalArgumentException::class, function($e) { return View::error(400, 'validation'); })
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([400, 'errors/validation'], [$view->status, $view->template]);
@@ -69,7 +69,7 @@ class ExceptionsTest {
   #[Test]
   public function mapping_throwable_to_catch_all() {
     $view= (new Exceptions())
-      ->mapping(Throwable::class)
+      ->catch(Throwable::class)
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
@@ -78,8 +78,8 @@ class ExceptionsTest {
   #[Test]
   public function order_is_relevant() {
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class, 400)
-      ->mapping(Throwable::class)
+      ->catch(IllegalArgumentException::class, 400)
+      ->catch(Throwable::class)
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([400, 'errors/400'], [$view->status, $view->template]);
@@ -88,8 +88,8 @@ class ExceptionsTest {
   #[Test]
   public function parent_shadows_type() {
     $view= (new Exceptions())
-      ->mapping(Throwable::class)
-      ->mapping(IllegalArgumentException::class, 400) // Not used in this case!
+      ->catch(Throwable::class)
+      ->catch(IllegalArgumentException::class, 400) // Not used in this case!
       ->handle(new IllegalArgumentException('test'))
     ;
     Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
@@ -98,7 +98,7 @@ class ExceptionsTest {
   #[Test]
   public function context_contains_exception() {
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class)
+      ->catch(IllegalArgumentException::class)
       ->handle(new IllegalArgumentException('test'))
     ;
 
@@ -109,7 +109,7 @@ class ExceptionsTest {
   public function context_from_callables_is_merged() {
     $handler= function($e) { return View::error(400, 'validation')->with(['type' => get_class($e)]); };
     $view= (new Exceptions())
-      ->mapping(IllegalArgumentException::class, $handler)
+      ->catch(IllegalArgumentException::class, $handler)
       ->handle(new IllegalArgumentException('test'))
     ;
 

--- a/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
@@ -1,0 +1,111 @@
+<?php namespace web\frontend\unittest;
+
+use lang\{IllegalArgumentException, Throwable};
+use unittest\{Assert, Expect, Test};
+use web\Error;
+use web\frontend\{Exceptions, View};
+
+class ExceptionsTest {
+
+  #[Test]
+  public function can_create() {
+    new Exceptions();
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: 'test')]
+  public function throws_error_if_not_mapped() {
+    (new Exceptions())->handle(new Error(404, 'test'));
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: 'test')]
+  public function throws_as_error_if_not_mapped() {
+    (new Exceptions())->handle(new IllegalArgumentException('test'));
+  }
+
+  #[Test]
+  public function mapping_web_error_uses_its_statuscode() {
+    $view= (new Exceptions())
+      ->mapping(Error::class)
+      ->handle(new Error(404, 'test'))
+    ;
+    Assert::equals([404, 'errors/404'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function mapping_exception_uses_500_as_statuscode() {
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function mapping_exception_to_statuscode() {
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class, 400)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([400, 'errors/400'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function mapping_exception_to_callable() {
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class, function($e) { return View::error(400, 'validation'); })
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([400, 'errors/validation'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function mapping_throwable_to_catch_all() {
+    $view= (new Exceptions())
+      ->mapping(Throwable::class)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function order_is_relevant() {
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class, 400)
+      ->mapping(Throwable::class)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([400, 'errors/400'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function parent_shadows_type() {
+    $view= (new Exceptions())
+      ->mapping(Throwable::class)
+      ->mapping(IllegalArgumentException::class, 400) // Not used in this case!
+      ->handle(new IllegalArgumentException('test'))
+    ;
+    Assert::equals([500, 'errors/500'], [$view->status, $view->template]);
+  }
+
+  #[Test]
+  public function context_contains_exception() {
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+
+    Assert::instance(IllegalArgumentException::class, $view->context['cause']);
+  }
+
+  #[Test]
+  public function context_from_callables_is_merged() {
+    $handler= function($e) { return View::error(400, 'validation')->with(['type' => get_class($e)]); };
+    $view= (new Exceptions())
+      ->mapping(IllegalArgumentException::class, $handler)
+      ->handle(new IllegalArgumentException('test'))
+    ;
+
+    Assert::equals(IllegalArgumentException::class, $view->context['type']);
+    Assert::instance(IllegalArgumentException::class, $view->context['cause']);
+  }
+}

--- a/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
+++ b/src/test/php/web/frontend/unittest/ExceptionsTest.class.php
@@ -22,6 +22,14 @@ class ExceptionsTest {
     (new Exceptions())->handle(new IllegalArgumentException('test'));
   }
 
+  #[Test, Expect(class: Error::class, withMessage: 'test')]
+  public function callable_returning_null_will_raise() {
+    (new Exceptions())
+      ->mapping(IllegalArgumentException::class, function($e) { return null; })
+      ->handle(new IllegalArgumentException('test'))
+    ;
+  }
+
   #[Test]
   public function mapping_web_error_uses_its_statuscode() {
     $view= (new Exceptions())

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -1,15 +1,15 @@
 <?php namespace web\frontend\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Expect, Test, TestCase};
+use unittest\{Assert, Before, Expect, Test};
 use web\frontend\unittest\actions\Users;
-use web\frontend\{Frontend, Templates};
+use web\frontend\{Frontend, Exceptions, RaiseErrors, Templates};
 
-class FrontendTest extends TestCase {
+class FrontendTest {
   private $templates;
 
-  /** @return void */
-  public function setUp() {
+  #[Before]
+  public function templates() {
     $this->templates= new class() implements Templates {
       public function write($template, $context, $out) { /* NOOP */ }
     };
@@ -27,17 +27,28 @@ class FrontendTest extends TestCase {
 
   #[Test]
   public function globals_empty_by_default() {
-    $this->assertEquals([], (new Frontend(new Users(), $this->templates))->globals);
+    Assert::equals([], (new Frontend(new Users(), $this->templates))->globals);
   }
 
   #[Test]
   public function globals_passed_to_constructor() {
     $globals= ['base' => '/', 'fingerprint' => '99b3825'];
-    $this->assertEquals($globals, (new Frontend(new Users(), $this->templates, $globals))->globals);
+    Assert::equals($globals, (new Frontend(new Users(), $this->templates, $globals))->globals);
   }
 
   #[Test]
   public function base_passed_to_constructor() {
-    $this->assertEquals(['base' => ''], (new Frontend(new Users(), $this->templates, '/'))->globals);
+    Assert::equals(['base' => ''], (new Frontend(new Users(), $this->templates, '/'))->globals);
+  }
+
+  #[Test]
+  public function raises_errors_by_default() {
+    Assert::instance(RaiseErrors::class, (new Frontend(new Users(), $this->templates))->errors());
+  }
+
+  #[Test]
+  public function changed_exception_handling() {
+    $h= new Exceptions();
+    Assert::equals($h, (new Frontend(new Users(), $this->templates))->handling($h)->errors());
   }
 }

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -47,6 +47,12 @@ class FrontendTest {
   }
 
   #[Test]
+  public function passed_exception_handling() {
+    $h= new Exceptions();
+    Assert::equals($h, (new Frontend(new Users(), $this->templates, [], $h))->errors());
+  }
+
+  #[Test]
   public function changed_exception_handling() {
     $h= new Exceptions();
     Assert::equals($h, (new Frontend(new Users(), $this->templates))->handling($h)->errors());

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\frontend\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Before, Expect, Test};
+use unittest\{Assert, Before, Expect, Test, Values};
 use web\frontend\unittest\actions\Users;
 use web\frontend\{Frontend, Exceptions, RaiseErrors, Templates};
 
@@ -32,13 +32,13 @@ class FrontendTest {
 
   #[Test]
   public function globals_passed_to_constructor() {
-    $globals= ['base' => '/', 'fingerprint' => '99b3825'];
+    $globals= ['base' => '', 'fingerprint' => '99b3825'];
     Assert::equals($globals, (new Frontend(new Users(), $this->templates, $globals))->globals);
   }
 
-  #[Test]
-  public function base_passed_to_constructor() {
-    Assert::equals(['base' => ''], (new Frontend(new Users(), $this->templates, '/'))->globals);
+  #[Test, Values([['/', ''], ['/test', '/test'], ['/test/', '/test']])]
+  public function base_passed_to_constructor($arg, $base) {
+    Assert::equals(['base' => $base], (new Frontend(new Users(), $this->templates, $arg))->globals);
   }
 
   #[Test]

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -139,13 +139,13 @@ class HandlingTest extends TestCase {
     );
   }
 
-  #[Test, Expect(['class' => Error::class, 'withMessage'=> '/Method PATCH not supported by any delegate/'])]
-  public function unsupported_verb() {
+  #[Test, Expect(['class' => Error::class, 'withMessage'=> '/Cannot route PATCH requests to .+/'])]
+  public function unsupported_route() {
     $fixture= new Frontend(new Users(), new class() implements Templates {
       public function write($template, $context, $out) { /* NOOP */ }
     });
 
-    $this->handle($fixture, 'PATCH', '/users/1', [], 'username=@illegal@');
+    $this->handle($fixture, 'PATCH', '/users/1', [], '(irrelevant)');
   }
 
   #[Test, Expect(['class' => Error::class, 'withMessage'=> '/Illegal username ".+"/'])]

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -9,6 +9,7 @@ class Users {
     1 => ['id' => 1, 'name' => 'Test'],
   ];
 
+
   #[Get('/users')]
   public function all(
     #[Param]

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -9,7 +9,6 @@ class Users {
     1 => ['id' => 1, 'name' => 'Test'],
   ];
 
-
   #[Get('/users')]
   public function all(
     #[Param]


### PR DESCRIPTION
Implements features suggested in #24. 

## Examples

```php
// Catch web.Error instances and map them to errors/{status}, all other exceptions
// will continue to display the basic xp-forge/web error pages
new Frontend($handlers, $templates, handling: (new Exceptions())->catch(Error::class));

// Report database connection and Neo4J query errors as 503 ("Service Unavailable"),
// supply catch-all to handle web.Errors as errors/{status} and all others as errors/500
new Frontend($handlers, $templates, handling: (new Exceptions())
  ->catch(SQLConnectException::class, 503)
  ->catch(QueryFailed::class, 503)
  ->catch(Throwable::class)
);
```

Logging can be done in the templates, e.g.:

```handlebars
{{#> layout}}
  {{#*inline "title"}}Internal error{{/inline}}
  {{#*inline "content"}}
    <div class="page-header">
      <h1>Skill Graph <small>{{t "Error 500"}}</small></h1>
    </div>

    <div class="ui error message">
      <div class="header">{{t "Internal error"}}</div>
      <p>{{cause.message}}</p>
    </div>

    {{! Exception including stack trace will be rendered to the server console !}}
    {{log request.uri.path "~" cause level="error"}}
  {{/inline}}
  {{#*inline "script"}}{{/inline}}
{{/layout}}
```

*Note: Failure to find an error template will result in an 500 Internal Server Error being raised and displayed in the basic xp-forge/web error page*