### PR TITLE
Add support for remote dependencies

### DIFF
--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -131,6 +131,9 @@ class BundleRunner {
             Console::writeLine("\e[33m", $version, "\e[0m)");
 
             $bundles[$name][]= new LibraryDependency($source, $version, $sources);
+          } else if (preg_match('/^https?:\/\//', $source)) {
+            Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mremote\e[0m)", $source);
+            $bundles[$name][]= new RemoteDependency($source, $sources);
           } else {
             Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mlocal %s\e[0m)", $source, $relative);
             $bundles[$name][]= new LocalDependency($relative->resolve($source), $sources);

--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -129,7 +129,6 @@ class BundleRunner {
             Console::writef("  - Resolving \e[32mnpm/%s\e[0m (\e[33m%s\e[0m => ", $source, $constraint);
             $version= $resolve->version($source, $constraint);
             Console::writeLine("\e[33m", $version, "\e[0m)");
-
             $bundles[$name][]= new LibraryDependency($source, $version, $sources);
           } else if (preg_match('/^https?:\/\//', $source)) {
             Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mremote\e[0m)", $source);

--- a/src/main/php/xp/frontend/RemoteDependency.class.php
+++ b/src/main/php/xp/frontend/RemoteDependency.class.php
@@ -1,0 +1,26 @@
+<?php namespace xp\frontend;
+
+use util\URI;
+
+class RemoteDependency extends Dependency {
+  private $base, $files;
+
+  /**
+   * Creates a new dependency
+   *
+   * @param  string|util.URI $base
+   * @param  string[] $files
+   */
+  public function __construct($base, array $files) {
+    $this->base= rtrim($base, '/');
+    $this->files= $files;
+  }
+
+  public function files() {
+    foreach ($this->files as $file) {
+      yield $file => function($cdn) use($file) {
+        return $cdn->fetch(new URI($this->base.'/'.$file));
+      };
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for remote dependencies, that is, dependencies downloaded from a HTTP(S) location. This feature completes local dependencies implemented in #20. 

## Example
The following shows a *package.json* using this feature.

```json
{
  "dependencies": {
    "fomantic-ui": "^2.8",
    "jquery": "^3.6"
  },
  "bundles": {
    "vendor": {
      "jquery": "dist/jquery.min.js",
      "fomantic-ui": "dist/semantic.min.js | dist/semantic.min.css",
      "https://cdn.amcharts.com/lib/4": "core.js | charts.js | themes/animated.js"
    }
  }
}
```

## Reasoning

While [amCharts](https://www.amcharts.com/docs/v4/) also [exists on JSDelivr](https://www.jsdelivr.com/package/npm/@amcharts/amcharts4), the files there are not pre-compiled and would need to be pre-processed, e.g. [with Webpack](https://www.amcharts.com/docs/v4/getting-started/integrations/using-webpack/). However, they also provide their own CDN (see [here](https://www.amcharts.com/download/)) which includes (quote) "ready-to-include CDN resources".