### PR TITLE
Add support for bundling web fonts

### DIFF
--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -109,9 +109,10 @@ class BundleRunner {
       'final'  => function($t) { Console::writef('%s%s', str_repeat(' ', strlen($t)), str_repeat("\x08", strlen($t))); },
     ];
     $handlers= [
-      'css' => new ProcessStylesheet($files),
-      'js'  => new ProcessJavaScript(),
-      '*'   => new StoreFile($files),
+      'fonts' => new ProcessFonts($files),
+      'css'   => new ProcessStylesheet($files),
+      'js'    => new ProcessJavaScript(),
+      '*'    => new StoreFile($files),
     ];
 
     try {
@@ -133,6 +134,9 @@ class BundleRunner {
           } else if (preg_match('/^https?:\/\//', $source)) {
             Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mremote\e[0m)", $source);
             $bundles[$name][]= new RemoteDependency($source, $sources);
+          } else if (preg_match('/^fonts?:\/\//', $source)) {
+            Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mfonts\e[0m)", implode(' & ', $sources));
+            $bundles[$name][]= new FontsDependency($source, $sources);
           } else {
             Console::writeLinef("  - Resolving \e[32m%s\e[0m (\e[33mlocal %s\e[0m)", $source, $relative);
             $bundles[$name][]= new LocalDependency($relative->resolve($source), $sources);

--- a/src/main/php/xp/frontend/FontsDependency.class.php
+++ b/src/main/php/xp/frontend/FontsDependency.class.php
@@ -1,0 +1,27 @@
+<?php namespace xp\frontend;
+
+use util\URI;
+
+/** @see https://developers.google.com/fonts/docs/css2 */
+class FontsDependency extends Dependency {
+  private $params, $families;
+
+  /**
+   * Creates a new dependency
+   *
+   * @param  string|util.URI $params
+   * @param  string[] $families
+   */
+  public function __construct($params, array $families) {
+    $this->params= str_replace('fonts://', '', $params);
+    $this->families= $families;
+  }
+
+  public function files() {
+    foreach ($this->families as $family) {
+      yield $family.'.fonts' => function($cdn) use($family) {
+        return $cdn->fetch(new URI('https://fonts.googleapis.com/css2?family='.$family.'&'.$this->params));
+      };
+    }
+  }
+}

--- a/src/main/php/xp/frontend/ProcessFonts.class.php
+++ b/src/main/php/xp/frontend/ProcessFonts.class.php
@@ -1,0 +1,34 @@
+<?php namespace xp\frontend;
+
+use io\streams\{Streams, InputStream};
+use io\{File, Folder};
+use util\URI;
+
+/** @see https://developers.google.com/fonts/docs/css2 */
+class ProcessFonts {
+  private $files;
+
+  /** @param xp.frontend.Files */
+  public function __construct($files) {
+    $this->files= $files;
+  }
+
+  public function process(Result $result, InputStream $stream, URI $uri= null) {
+    $bytes= Streams::readAll($stream);
+
+    // Download fonts
+    preg_match_all('/src: url\(([^)]+)\)/', $bytes, $resources, PREG_SET_ORDER);
+    foreach ($resources as $resource) {
+      $uri= new URI(trim($resource[1], '"\''));
+      $file= $this->files->store(
+        $result->fetch($stream->origin->resolve($uri), !$stream->cached()),
+        $uri->path()
+      );
+
+      // Update CSS with stored file's filename
+      $bytes= str_replace($resource[0], 'src: url('.$file->filename.')', $bytes);
+    }
+
+    $result->concat('css', $bytes);
+  }
+}


### PR DESCRIPTION
## Configuration

Use this in *package.json*:

```json
{
  "bundles": {
    "vendor": {
      "fonts://display=swap": "Overpass | Lato"
    }
  }
}
```

## Usage

![image](https://user-images.githubusercontent.com/696742/189996352-6005efd1-8e0a-41e7-bb28-e7c509bc53bc.png)

## Resulting CSS

```css
@font-face {
  font-family: 'Overpass';
  font-style: normal;
  font-weight: 400;
  font-display: swap;
  src: url(qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOQ.bb5a7dd.ttf) format('truetype');
}
```

The TTF file is downloaded and stored alongside the CSS file.

* * *

Uses https://developers.google.com/fonts/docs/css2
See https://www.webdesign-journal.de/google-webfonts-einbindung-dsgvo/