### PR TITLE
Compress assets downloaded as dependencies

### DIFF
--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -45,6 +45,13 @@ class Bundle implements OutputStream {
   }
 
   /**
+   * Returns the name under which this bundle was stored
+   *
+   * @return string
+   */
+  public function name() { return $this->files['']->filename; }
+
+  /**
    * Returns the files produced by this bundle
    *
    * @return [:io.File]

--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -4,6 +4,8 @@ use io\File;
 use io\streams\{OutputStream, GzCompressingOutputStream};
 
 class Bundle implements OutputStream {
+  const COMPRESS = ['css', 'js', 'svg', 'json', 'xml', 'ttf', 'woff', 'woff2', 'eot'];
+
   private static $zlib, $brotli;
   private $files= [];
   private $output= [];
@@ -16,34 +18,35 @@ class Bundle implements OutputStream {
   /**
    * Creates a new bundle
    *
-   * @param  io.Folder|string $path
-   * @param  string $name
+   * @param  io.Path|string $path
+   * @param  ?string $type
    */
-  public function __construct($path, $name) {
-    $this->output[]= $this->output(new File($path, $name));
-    if (self::$zlib) {
-      $this->output[]= new GzCompressingOutputStream($this->output(new File($path, $name.'.gz')), 9);
-    }
-    if (self::$brotli) {
-      $this->output[]= new BrCompressingOutputStream($this->output(new File($path, $name.'.br')), 11); 
+  public function __construct($path, $type= null) {
+    $this->output[]= $this->output($path);
+
+    // Check whether it's typically worthwhile compressin a file.
+    if (in_array($type ?? substr($path, strrpos($path, '.') + 1), self::COMPRESS)) {
+      self::$zlib && $this->output[]= new GzCompressingOutputStream($this->output($path, '.gz'), 9);
+      self::$brotli && $this->output[]= new BrCompressingOutputStream($this->output($path, '.br'), 11);
     }
   }
 
   /**
    * Registers a given file and returns its output stream
    *
-   * @param  io.File $file
+   * @param  io.Path $path
+   * @param  string $suffix
    * @param  io.OutputStream
    */
-  private function output($file) {
-    $this->files[]= $file;
+  private function output($path, $suffix= '') {
+    $this->files[$suffix]= $file= new File($path.$suffix);
     return $file->out();
   }
 
   /**
    * Returns the files produced by this bundle
    *
-   * @return io.File[]
+   * @return [:io.File]
    */
   public function files() { return $this->files; }
 

--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -24,7 +24,8 @@ class Bundle implements OutputStream {
   public function __construct($path, $type= null) {
     $this->output[]= $this->output($path);
 
-    // Check whether it's typically worthwhile compressin a file.
+    // Check whether it's typically worthwhile compressing a file based on the
+    // given type (falling back to the file extension if omitted).
     if (in_array($type ?? substr($path, strrpos($path, '.') + 1), self::COMPRESS)) {
       self::$zlib && $this->output[]= new GzCompressingOutputStream($this->output($path, '.gz'), 9);
       self::$brotli && $this->output[]= new BrCompressingOutputStream($this->output($path, '.br'), 11);
@@ -34,7 +35,7 @@ class Bundle implements OutputStream {
   /**
    * Registers a given file and returns its output stream
    *
-   * @param  io.Path $path
+   * @param  io.Path|string $path
    * @param  string $suffix
    * @param  io.OutputStream
    */

--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -4,7 +4,7 @@ use io\File;
 use io\streams\{OutputStream, GzCompressingOutputStream};
 
 class Bundle implements OutputStream {
-  const COMPRESS = ['css', 'js', 'svg', 'json', 'xml', 'ttf', 'woff', 'woff2', 'eot'];
+  const COMPRESS = ['css', 'js', 'svg', 'json', 'xml', 'ttf', 'otf', 'woff', 'woff2', 'eot'];
 
   private static $zlib, $brotli;
   private $files= [];
@@ -26,7 +26,7 @@ class Bundle implements OutputStream {
 
     // Check whether it's typically worthwhile compressing a file based on the
     // given type (falling back to the file extension if omitted).
-    if (in_array($type ?? substr($path, strrpos($path, '.') + 1), self::COMPRESS)) {
+    if (in_array($type ?? strtolower(substr($path, strrpos($path, '.') + 1)), self::COMPRESS)) {
       self::$zlib && $this->output[]= new GzCompressingOutputStream($this->output($path, '.gz'), 9);
       self::$brotli && $this->output[]= new BrCompressingOutputStream($this->output($path, '.br'), 11);
     }

--- a/src/main/php/xp/frontend/Bundle.class.php
+++ b/src/main/php/xp/frontend/Bundle.class.php
@@ -4,7 +4,7 @@ use io\File;
 use io\streams\{OutputStream, GzCompressingOutputStream};
 
 class Bundle implements OutputStream {
-  const COMPRESS = ['css', 'js', 'svg', 'json', 'xml', 'ttf', 'otf', 'woff', 'woff2', 'eot'];
+  const COMPRESS = ['css', 'js', 'svg', 'json', 'xml', 'ttf', 'otf', 'eot'];
 
   private static $zlib, $brotli;
   private $files= [];

--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -155,7 +155,7 @@ class BundleRunner {
         }
 
         foreach ($result->sources() as $type => $source) {
-          $bundle= new Bundle($target, $files->resolve($name, $type, $source->hash));
+          $bundle= new Bundle(new Path($target, $files->resolve($name, $type, $source->hash)));
           with ($source, $bundle, function($in, $target) {
             $in->transfer($target);
           });
@@ -171,7 +171,7 @@ class BundleRunner {
       if ($manifest) {
         Console::writeLinef("\e[32mCleaning up previous versions\e[0m");
         foreach ($manifest->removed() as $remove) {
-          $bundle= new Bundle($target, $remove);
+          $bundle= new Bundle(new Path($target, $remove));
           $bundle->close();
           foreach ($bundle->files() as $file) {
             $path= str_replace($cwd->getURI(), '', realpath($file->getURI()));

--- a/src/main/php/xp/frontend/BundleRunner.class.php
+++ b/src/main/php/xp/frontend/BundleRunner.class.php
@@ -155,11 +155,7 @@ class BundleRunner {
         }
 
         foreach ($result->sources() as $type => $source) {
-          $bundle= new Bundle(new Path($target, $files->resolve($name, $type, $source->hash)));
-          with ($source, $bundle, function($in, $target) {
-            $in->transfer($target);
-          });
-
+          $bundle= $files->store($source, new Path($target, $name.'.'.$type));
           foreach ($bundle->files() as $file) {
             $path= str_replace($cwd->getURI(), '', realpath($file->getURI()));
             Console::writeLinef("\r\e[0K> %s: \e[33m%.2f kB\e[0m", $path, $file->size() / 1024);

--- a/src/main/php/xp/frontend/Files.class.php
+++ b/src/main/php/xp/frontend/Files.class.php
@@ -12,8 +12,6 @@ abstract class Files {
     $this->target->exists() || $this->target->create();
   }
 
-  public abstract function resolve($name, $type, $hash);
-
   /**
    * Store a given input stream under a given name and return file its
    * contents were written to.

--- a/src/main/php/xp/frontend/Files.class.php
+++ b/src/main/php/xp/frontend/Files.class.php
@@ -20,6 +20,6 @@ abstract class Files {
    *
    * @throws io.IOException
    */
-  public abstract function store(InputStream $in, string $path): File;
+  public abstract function store(InputStream $in, string $path): Bundle;
 
 }

--- a/src/main/php/xp/frontend/ProcessFonts.class.php
+++ b/src/main/php/xp/frontend/ProcessFonts.class.php
@@ -17,7 +17,7 @@ class ProcessFonts {
     $bytes= Streams::readAll($stream);
 
     // Download fonts
-    preg_match_all('/src: url\(([^)]+)\)/', $bytes, $resources, PREG_SET_ORDER);
+    preg_match_all('/url\(([^)]+)\)/', $bytes, $resources, PREG_SET_ORDER);
     foreach ($resources as $resource) {
       $uri= new URI(trim($resource[1], '"\''));
       $bundle= $this->files->store(
@@ -26,7 +26,7 @@ class ProcessFonts {
       );
 
       // Update CSS with stored file's filename
-      $bytes= str_replace($resource[0], 'src: url('.$bundle->name().')', $bytes);
+      $bytes= str_replace($resource[0], 'url('.$bundle->name().')', $bytes);
     }
 
     $result->concat('css', $bytes);

--- a/src/main/php/xp/frontend/ProcessFonts.class.php
+++ b/src/main/php/xp/frontend/ProcessFonts.class.php
@@ -20,13 +20,13 @@ class ProcessFonts {
     preg_match_all('/src: url\(([^)]+)\)/', $bytes, $resources, PREG_SET_ORDER);
     foreach ($resources as $resource) {
       $uri= new URI(trim($resource[1], '"\''));
-      $file= $this->files->store(
+      $bundle= $this->files->store(
         $result->fetch($stream->origin->resolve($uri), !$stream->cached()),
         $uri->path()
       );
 
       // Update CSS with stored file's filename
-      $bytes= str_replace($resource[0], 'src: url('.$file->filename.')', $bytes);
+      $bytes= str_replace($resource[0], 'src: url('.$bundle->name().')', $bytes);
     }
 
     $result->concat('css', $bytes);

--- a/src/main/php/xp/frontend/ProcessStylesheet.class.php
+++ b/src/main/php/xp/frontend/ProcessStylesheet.class.php
@@ -21,13 +21,13 @@ class ProcessStylesheet {
     foreach ($resources as $resource) {
       $uri= new URI(trim($resource[1], '"\''));
       if ($uri->isRelative()) {
-        $file= $this->files->store(
+        $bundle= $this->files->store(
           $result->fetch($stream->origin->resolve($uri), !$stream->cached()),
           $uri->path()
         );
 
-        // Update CSS with stored file's filename
-        $bytes= str_replace($resource[0], 'url('.$file->filename.')', $bytes);
+        // Update CSS with stored bundle's filename
+        $bytes= str_replace($resource[0], 'url('.$bundle->name().')', $bytes);
       }
     }
 

--- a/src/main/php/xp/frontend/Source.class.php
+++ b/src/main/php/xp/frontend/Source.class.php
@@ -1,9 +1,8 @@
 <?php namespace xp\frontend;
 
-use io\streams\OutputStream;
-use lang\Closeable;
+use io\streams\InputStream;
 
-class Source implements Closeable {
+class Source implements InputStream {
   private $list;
   public $hash;
 
@@ -13,14 +12,14 @@ class Source implements Closeable {
     $this->hash= $hash;
   }
 
-  /** Transfers this source to an output stream */
-  public function transfer(OutputStream $out): self {
-    foreach ($this->list as $bytes) {
-      foreach ($bytes as $chunk) {
-        $out->write($chunk);
-      }
-    }
-    return $this;
+  /** @return int */
+  public function available() {
+    return sizeof($this->list);
+  }
+
+  /** @return string */
+  public function read($bytes= 8192) {
+    return implode('', array_pop($this->list));
   }
 
   /** @return void */

--- a/src/main/php/xp/frontend/UsingFilenames.class.php
+++ b/src/main/php/xp/frontend/UsingFilenames.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\frontend;
 
-use io\File;
 use io\streams\InputStream;
+use io\{Path, File};
 
 /** Stores assets and dependencies by their original filenames */
 class UsingFilenames extends Files {
@@ -16,9 +16,8 @@ class UsingFilenames extends Files {
    *
    * @throws io.IOException
    */
-  public function store(InputStream $in, string $path): File {
-    $out= new File($this->target, basename($path));
-    $out->open(File::WRITE);
+  public function store(InputStream $in, string $path): Bundle {
+    $out= new Bundle(new Path($this->target, basename($path)));
     try {
       while ($in->available()) {
         $out->write($in->read());

--- a/src/main/php/xp/frontend/UsingFilenames.class.php
+++ b/src/main/php/xp/frontend/UsingFilenames.class.php
@@ -6,10 +6,6 @@ use io\streams\InputStream;
 /** Stores assets and dependencies by their original filenames */
 class UsingFilenames extends Files {
 
-  public function resolve($name, $type, $hash) {
-    return $name.'.'.$type;
-  }
-
   /**
    * Store a given input stream under a given name and return file its
    * contents were written to.

--- a/src/main/php/xp/frontend/UsingFilenames.class.php
+++ b/src/main/php/xp/frontend/UsingFilenames.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\frontend;
 
+use io\Path;
 use io\streams\InputStream;
-use io\{Path, File};
 
 /** Stores assets and dependencies by their original filenames */
 class UsingFilenames extends Files {

--- a/src/main/php/xp/frontend/WithFingerprints.class.php
+++ b/src/main/php/xp/frontend/WithFingerprints.class.php
@@ -22,13 +22,6 @@ class WithFingerprints extends Files {
     return $name.'.'.substr($hash, 0, 7).'.'.$type;
   }
 
-  public function resolve($name, $type, $hash) {
-    return $this->manifest->associate(
-      $name.'.'.$type,
-      $this->hashed($name, $type, $hash)
-    );
-  }
-
   /**
    * Store a given input stream under a given name and return file its
    * contents were written to.
@@ -55,7 +48,10 @@ class WithFingerprints extends Files {
 
     // Register in manifest
     $name= basename($path, '.'.$type);
-    $this->resolve($name, $type, $hash);
+    $this->manifest->associate(
+      $name.'.'.$type,
+      $this->hashed($name, $type, $hash)
+    );
 
     // Rename the files to [filename].[contenthash].[extension]
     foreach ($out->files() as $suffix => $file) {

--- a/src/main/php/xp/frontend/WithFingerprints.class.php
+++ b/src/main/php/xp/frontend/WithFingerprints.class.php
@@ -1,6 +1,5 @@
 <?php namespace xp\frontend;
 
-use io\File;
 use io\streams\InputStream;
 
 /** Stores assets and dependencies by with fingerprints in their filenames */


### PR DESCRIPTION
These file types will be compressed, see https://letstalkaboutwebperf.com/en/gzip-brotli-server-config/ and https://www.phpied.com/gzip-your-font-face-files/

* [x] .css
* [x] .js
* [x] .svg
* [x] .json
* [x] .xml
* [x] .ttf
* [x] .eot

* * * 

If we can deliver the following TrueType font with Brotli compression, the savings will be around **100 kilobytes**:

```diff
 -rwxr-xr-x  1 timmf timmf    133 Sep 14 21:41 manifest.json
--rwxr-xr-x  1 timmf timmf 164120 Sep 14 21:41 qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOQ.bb5a7dd.ttf
+-rwxr-xr-x  1 timmf timmf 164120 Sep 14 23:06 qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOQ.bb5a7dd.ttf
+-rwxr-xr-x  1 timmf timmf  66810 Sep 14 23:06 qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOQ.bb5a7dd.ttf.br
+-rwxr-xr-x  1 timmf timmf  81367 Sep 14 23:06 qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOQ.bb5a7dd.ttf.gz
```
