### PR TITLE
Implement default security policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ To configure framing, referrer and content security policies, use the *security(
 ```php
 use web\Frontend;
 
-$frontend= (new Frontend(new HandlersIn('org.example.web'), $templates));
+$frontend= new Frontend($delegates, $templates);
 $frontend->security()
   ->framing('SAMEORIGIN')
   ->referrers('strict-origin')

--- a/README.md
+++ b/README.md
@@ -272,6 +272,33 @@ Using our handlebars engine from above, the template *errors/404.handlebars* cou
 </html>
 ```
 
+## Security
+
+This library sets the following security header defaults:
+
+* `X-Content-Type-Options: nosniff`
+* `X-Frame-Options: DENY`
+* `Referrer-Policy: no-referrer-when-downgrade`
+
+To configure framing, referrer and content security policies, use the *security()* fluent interface:
+
+```php
+use web\Frontend;
+
+$frontend= (new Frontend(new HandlersIn('org.example.web'), $templates));
+$frontend->security()
+  ->framing('SAMEORIGIN')
+  ->referrers('strict-origin')
+  ->csp([
+    'default-src' => '"none"',
+    'script-src'  => ['"self"', '"nonce-{{nonce}}"', 'https://example.com'],
+    // etcetera
+  ])
+;
+```
+
+Read more about hardening response headers at https://scotthelme.co.uk/hardening-your-http-response-headers/ or watch this talk: https://www.youtube.com/watch?v=mr230uotw-Y
+
 ## Performance
 
 When using the production servers, the application's code is only compiled and its setup only runs once. This gives us lightning-fast response times:

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The bundler can also resolve local files, URLs as well as [Google fonts](https:/
 By default, errors and exceptions will yield in a minimalistic error page with the corresponding error code (*defaulting to 500 Internal Server Error*) shown. Exceptions can be handled by a closure, a status code or by default, and decide to return a view of their own. This view is loaded from the *errors/* subfolder and passed a context of `['cause' => $exception]`.
 
 ```php
-use web\frontend\{HandlersIn, FrontendIn, Exceptions};
+use web\frontend\{HandlersIn, Frontend, Exceptions};
 use org\example\{InvalidOrder, LinkExpired};
 use lang\Throwable;
 
@@ -283,17 +283,18 @@ This library sets the following security header defaults:
 To configure framing, referrer and content security policies, use the *security()* fluent interface:
 
 ```php
-use web\Frontend;
+use web\frontend\{Frontend, Security};
 
-$frontend= new Frontend($delegates, $templates);
-$frontend->security()
-  ->framing('SAMEORIGIN')
-  ->referrers('strict-origin')
-  ->csp([
-    'default-src' => '"none"',
-    'script-src'  => ['"self"', '"nonce-{{nonce}}"', 'https://example.com'],
-    // etcetera
-  ])
+$frontend= (new Frontend($delegates, $templates))
+  ->enacting((new Security())
+    ->framing('SAMEORIGIN')
+    ->referrers('strict-origin')
+    ->csp([
+      'default-src' => '"none"',
+      'script-src'  => ['"self"', '"nonce-{{nonce}}"', 'https://example.com'],
+      // etcetera
+    ])
+  )
 ;
 ```
 

--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ Using our handlebars engine from above, the template *errors/404.handlebars* cou
 
 This library sets the following security header defaults:
 
-* `X-Content-Type-Options: nosniff`
-* `X-Frame-Options: DENY`
-* `Referrer-Policy: no-referrer-when-downgrade`
+* `X-Content-Type-Options: nosniff` - prevents browsers from [MIME sniffing](https://mimesniff.spec.whatwg.org/)
+* `X-Frame-Options: DENY` - prevents site from being embedded in an `<iframe>`.
+* `Referrer-Policy: no-referrer-when-downgrade` - doesn't send HTTP referrer over unencrypted connections.
 
 To configure framing, referrer and content security policies, use the *security()* fluent interface:
 

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -11,7 +11,7 @@ use web\{Error, Handler};
  * @test  web.frontend.unittest.CSRFTokenTest
  */
 class Frontend implements Handler {
-  private $delegates, $templates, $errors;
+  private $delegates, $templates, $errors, $security;
   public $globals;
 
   /**

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -27,7 +27,11 @@ class Frontend implements Handler {
     $this->templates= $templates;
     $this->globals= is_string($globals) ? ['base' => rtrim($globals, '/')] : $globals;
     $this->errors= $handling;
+    $this->security= new Security();
   }
+
+  /** Returns security controls */
+  public function security(): Security { return $this->security; }
 
   /** Overwrites error handler */
   public function handling(Errors $errors): self {
@@ -83,6 +87,9 @@ class Frontend implements Handler {
    */
   public function handle($req, $res) {
     $res->header('Server', 'XP/Frontend');
-    $this->view($req, $res)->using($this->templates)->transfer($req, $res, $this->globals);
+    $this->security->apply($this->view($req, $res))
+      ->using($this->templates)
+      ->transfer($req, $res, $this->globals)
+    ;
   }
 }

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -11,7 +11,8 @@ use web\{Error, Handler};
  * @test  web.frontend.unittest.CSRFTokenTest
  */
 class Frontend implements Handler {
-  private $delegates, $templates, $errors, $security;
+  private $delegates, $templates, $errors;
+  private $security= null;
   public $globals;
 
   /**
@@ -27,11 +28,7 @@ class Frontend implements Handler {
     $this->templates= $templates;
     $this->globals= is_string($globals) ? ['base' => rtrim($globals, '/')] : $globals;
     $this->errors= $handling;
-    $this->security= new Security();
   }
-
-  /** Returns security controls */
-  public function security(): Security { return $this->security; }
 
   /** Overwrites error handler */
   public function handling(Errors $errors): self {
@@ -39,9 +36,20 @@ class Frontend implements Handler {
     return $this;
   }
 
+  /** Overwrites security */
+  public function enacting(Security $security): self {
+    $this->security= $security;
+    return $this;
+  }
+
   /** Returns error handler */
   public function errors(): Errors {
     return $this->errors ?? $this->errors= new RaiseErrors();
+  }
+
+  /** Returns security */
+  public function security(): Security {
+    return $this->security ?? $this->security= new Security();
   }
 
   /**
@@ -87,7 +95,7 @@ class Frontend implements Handler {
    */
   public function handle($req, $res) {
     $res->header('Server', 'XP/Frontend');
-    $this->security->apply($this->view($req, $res))
+    $this->security()->apply($this->view($req, $res))
       ->using($this->templates)
       ->transfer($req, $res, $this->globals)
     ;

--- a/src/main/php/web/frontend/Security.class.php
+++ b/src/main/php/web/frontend/Security.class.php
@@ -1,0 +1,68 @@
+<?php namespace web\frontend;
+
+use util\Random;
+
+/**
+ * Security headers
+ *
+ * @see   https://www.youtube.com/watch?v=mr230uotw-Y
+ * @see   https://scotthelme.co.uk/hardening-your-http-response-headers/
+ * @see   https://webhint.io/docs/user-guide/hints/hint-x-content-type-options/
+ * @test  web.frontend.unittest.SecurityTest
+ */
+class Security {
+  private $headers= [
+    'X-Content-Type-Options'  => 'nosniff',
+    'X-Frame-Options'         => 'DENY',
+    'Referrer-Policy'         => 'no-referrer-when-downgrade',
+  ];
+
+  /** Sets frame options */
+  public function framing(string $value): self {
+    $this->headers['X-Frame-Options']= $value;
+    return $this;
+  }
+
+  /** Sets referrer policy */
+  public function referrers(string $value): self {
+    $this->headers['Referrer-Policy']= $value;
+    return $this;
+  }
+
+  /**
+   * Sets content security policy
+   * 
+   * @param  [:string|string[]] $sources
+   * @param  bool $reportOnly whether to report only (true) or to enforce (false)
+   * @return self
+   */
+  public function csp(array $sources, bool $reportOnly= false): self {
+    $name= $reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
+    $header= '';
+    foreach ($sources as $source => $value) {
+      $header.= '; '.$source.' '.(is_array($value) ? implode(' ', $value) : $value);
+    }
+    $this->headers[$name]= substr($header, 2);
+    return $this;
+  }
+
+  /**
+   * Passes security headers and context to view and returns it.
+   *
+   * @param  web.frontend.View
+   * @return web.frontend.View
+   */
+  public function apply($view) {
+    $variables= [];
+    foreach ($this->headers as $name => $value) {
+      $view->header($name, preg_replace_callback(
+        '/\{\{\s?([^}]+)\s?\}\}/',
+        function($m) use($view, &$variables) {
+          return $variables[$m[1]] ?? $variables[$m[1]]= bin2hex((new Random())->bytes(16));
+        },
+        $value
+      ));
+    }
+    return $view->with($variables);
+  }
+}

--- a/src/main/php/web/frontend/Security.class.php
+++ b/src/main/php/web/frontend/Security.class.php
@@ -35,6 +35,7 @@ class Security {
    * @param  [:string|string[]] $sources
    * @param  bool $reportOnly whether to report only (true) or to enforce (false)
    * @return self
+   * @see    https://content-security-policy.com/
    */
   public function csp(array $sources, bool $reportOnly= false): self {
     $name= $reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';

--- a/src/main/php/web/frontend/Security.class.php
+++ b/src/main/php/web/frontend/Security.class.php
@@ -41,7 +41,7 @@ class Security {
     $name= $reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy';
     $header= '';
     foreach ($sources as $source => $value) {
-      $header.= '; '.$source.' '.(is_array($value) ? implode(' ', $value) : $value);
+      $header.= '; '.$source.' '.strtr(is_array($value) ? implode(' ', $value) : $value, '"', "'");
     }
     $this->headers[$name]= substr($header, 2);
     return $this;

--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -81,7 +81,7 @@ class View {
    * @return self
    */
   public function with(array $context) {
-    $this->context+= $context;
+    null === $this->context || $this->context+= $context;
     return $this;
   }
 
@@ -113,6 +113,7 @@ class View {
    *
    * @param  web.Request $req
    * @param  web.Response $res
+   * @param  [:var] $globals
    * @return void
    */
   public function transfer($req, $res, $globals) {
@@ -128,9 +129,7 @@ class View {
       $this->context+= $globals;
       $this->context['request']= $req;
 
-      // See https://webhint.io/docs/user-guide/hints/hint-x-content-type-options/
       $res->header('Content-Type', 'text/html; charset='.\xp::ENCODING);
-      $res->header('X-Content-Type-Options', 'nosniff');
       $out= $res->stream();
       try {
         $this->templates->write($this->template, $this->context, $out);

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -60,6 +60,7 @@ class FrontendTest {
 
   #[Test]
   public function security() {
-    Assert::instance(Security::class, (new Frontend(new Users(), $this->templates))->security());
+    $s= new Security();
+    Assert::equals($s, (new Frontend(new Users(), $this->templates))->enacting($s)->security());
   }
 }

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -3,7 +3,7 @@
 use lang\IllegalArgumentException;
 use unittest\{Assert, Before, Expect, Test, Values};
 use web\frontend\unittest\actions\Users;
-use web\frontend\{Frontend, Exceptions, RaiseErrors, Templates};
+use web\frontend\{Frontend, Exceptions, Security, RaiseErrors, Templates};
 
 class FrontendTest {
   private $templates;
@@ -56,5 +56,10 @@ class FrontendTest {
   public function changed_exception_handling() {
     $h= new Exceptions();
     Assert::equals($h, (new Frontend(new Users(), $this->templates))->handling($h)->errors());
+  }
+
+  #[Test]
+  public function security() {
+    Assert::instance(Security::class, (new Frontend(new Users(), $this->templates))->security());
   }
 }

--- a/src/test/php/web/frontend/unittest/SecurityTest.class.php
+++ b/src/test/php/web/frontend/unittest/SecurityTest.class.php
@@ -2,7 +2,7 @@
 
 use unittest\{Assert, Before, Test};
 use web\frontend\unittest\actions\Home;
-use web\frontend\{Frontend, Templates};
+use web\frontend\{Frontend, Security, Templates};
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 
@@ -49,7 +49,7 @@ class SecurityTest {
   #[Test]
   public function change_x_frame_options() {
     $fixture= new Frontend(new Home(), $this->templates);
-    $fixture->security()->framing('SAMEORIGIN');
+    $fixture->enacting((new Security())->framing('SAMEORIGIN'));
     $res= $this->handle($fixture);
 
     Assert::equals('SAMEORIGIN', $res->headers()['X-Frame-Options']);
@@ -66,7 +66,7 @@ class SecurityTest {
   #[Test]
   public function change_referrer_policy() {
     $fixture= new Frontend(new Home(), $this->templates);
-    $fixture->security()->referrers('strict-origin');
+    $fixture->enacting((new Security())->referrers('strict-origin'));
     $res= $this->handle($fixture);
 
     Assert::equals('strict-origin', $res->headers()['Referrer-Policy']);
@@ -75,10 +75,10 @@ class SecurityTest {
   #[Test]
   public function add_content_security_policy() {
     $fixture= new Frontend(new Home(), $this->templates);
-    $fixture->security()->csp([
+    $fixture->enacting((new Security())->csp([
       'default-src' => '"none"',
       'script-src'  => ['"self"', '"nonce-1234"', 'https://example.com']
-    ]);
+    ]));
     $res= $this->handle($fixture);
 
     Assert::equals(
@@ -90,7 +90,7 @@ class SecurityTest {
   #[Test]
   public function add_report_only_content_security_policy() {
     $fixture= new Frontend(new Home(), $this->templates);
-    $fixture->security()->csp(['default-src' => '"none"'], true);
+    $fixture->enacting((new Security())->csp(['default-src' => '"none"'], true));
     $res= $this->handle($fixture);
 
     Assert::equals(
@@ -106,7 +106,7 @@ class SecurityTest {
         $result= $context;
       }
     ]));
-    $fixture->security()->csp(['script-src' => '"nonce-{{nonce}}"']);
+    $fixture->enacting((new Security())->csp(['script-src' => '"nonce-{{nonce}}"']));
     $res= $this->handle($fixture);
 
     preg_match('/script-src "nonce-([^"]+)"/', $res->headers()['Content-Security-Policy'], $m);
@@ -121,7 +121,7 @@ class SecurityTest {
         $result= $context;
       }
     ]));
-    $fixture->security()->csp(['script-src' => '"nonce-{{nonce}}"']);
+    $fixture->enacting((new Security())->csp(['script-src' => '"nonce-{{nonce}}"']));
 
     Assert::notEquals(
       $this->handle($fixture)->headers()['Content-Security-Policy'],

--- a/src/test/php/web/frontend/unittest/SecurityTest.class.php
+++ b/src/test/php/web/frontend/unittest/SecurityTest.class.php
@@ -116,11 +116,7 @@ class SecurityTest {
 
   #[Test]
   public function nonce_generated_is_unique_for_every_request() {
-    $fixture= new Frontend(new Home(), newinstance(Templates::class, [], [
-      'write' => function($template, $context= [], $out) use(&$result) {
-        $result= $context;
-      }
-    ]));
+    $fixture= new Frontend(new Home(), $this->templates);
     $fixture->enacting((new Security())->csp(['script-src' => '"nonce-{{nonce}}"']));
 
     Assert::notEquals(

--- a/src/test/php/web/frontend/unittest/SecurityTest.class.php
+++ b/src/test/php/web/frontend/unittest/SecurityTest.class.php
@@ -76,13 +76,25 @@ class SecurityTest {
   public function add_content_security_policy() {
     $fixture= new Frontend(new Home(), $this->templates);
     $fixture->enacting((new Security())->csp([
-      'default-src' => '"none"',
-      'script-src'  => ['"self"', '"nonce-1234"', 'https://example.com']
+      'default-src' => "'none'",
+      'script-src'  => ["'self'", "'nonce-1234'", 'https://example.com']
     ]));
     $res= $this->handle($fixture);
 
     Assert::equals(
-      'default-src "none"; script-src "self" "nonce-1234" https://example.com',
+      "default-src 'none'; script-src 'self' 'nonce-1234' https://example.com",
+      $res->headers()['Content-Security-Policy']
+    );
+  }
+
+  #[Test]
+  public function csp_double_quotes_are_replaced_by_single_quotes() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $fixture->enacting((new Security())->csp(['default-src' => '"none"']));
+    $res= $this->handle($fixture);
+
+    Assert::equals(
+      "default-src 'none'",
       $res->headers()['Content-Security-Policy']
     );
   }
@@ -90,11 +102,11 @@ class SecurityTest {
   #[Test]
   public function add_report_only_content_security_policy() {
     $fixture= new Frontend(new Home(), $this->templates);
-    $fixture->enacting((new Security())->csp(['default-src' => '"none"'], true));
+    $fixture->enacting((new Security())->csp(['default-src' => "'none'"], true));
     $res= $this->handle($fixture);
 
     Assert::equals(
-      'default-src "none"',
+      "default-src 'none'",
       $res->headers()['Content-Security-Policy-Report-Only']
     );
   }
@@ -109,7 +121,7 @@ class SecurityTest {
     $fixture->enacting((new Security())->csp(['script-src' => '"nonce-{{nonce}}"']));
     $res= $this->handle($fixture);
 
-    preg_match('/script-src "nonce-([^"]+)"/', $res->headers()['Content-Security-Policy'], $m);
+    preg_match("/script-src 'nonce-([^']+)'/", $res->headers()['Content-Security-Policy'], $m);
     Assert::equals(32, strlen($m[1]), 'nonce must consist of 32 bytes "'.$m[1].'"');
     Assert::equals($m[1], $result['nonce'] ?? null, 'nonce must appear in content');
   }

--- a/src/test/php/web/frontend/unittest/SecurityTest.class.php
+++ b/src/test/php/web/frontend/unittest/SecurityTest.class.php
@@ -1,0 +1,131 @@
+<?php namespace web\frontend\unittest;
+
+use unittest\{Assert, Before, Test};
+use web\frontend\unittest\actions\Home;
+use web\frontend\{Frontend, Templates};
+use web\io\{TestInput, TestOutput};
+use web\{Request, Response};
+
+class SecurityTest {
+  private $templates;
+
+  #[Before]
+  public function templates() {
+    $this->templates= new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    };
+  }
+
+  /**
+   * Calls fixture's `handle()` method
+   *
+   * @param  web.frontend.Frontend $fixture
+   * @return web.Response
+   */
+  private function handle($fixture) {
+    $req= new Request(new TestInput('GET', '/'));
+    $res= new Response(new TestOutput());
+    $fixture->handle($req, $res);
+
+    return $res;
+  }
+
+  #[Test]
+  public function x_content_type_options_header_always_nosniff() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $res= $this->handle($fixture);
+
+    Assert::equals('nosniff', $res->headers()['X-Content-Type-Options']);
+  }
+
+  #[Test]
+  public function x_frame_options_header_default() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $res= $this->handle($fixture);
+
+    Assert::equals('DENY', $res->headers()['X-Frame-Options']);
+  }
+
+  #[Test]
+  public function change_x_frame_options() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $fixture->security()->framing('SAMEORIGIN');
+    $res= $this->handle($fixture);
+
+    Assert::equals('SAMEORIGIN', $res->headers()['X-Frame-Options']);
+  }
+
+  #[Test]
+  public function referrer_policy_default() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $res= $this->handle($fixture);
+
+    Assert::equals('no-referrer-when-downgrade', $res->headers()['Referrer-Policy']);
+  }
+
+  #[Test]
+  public function change_referrer_policy() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $fixture->security()->referrers('strict-origin');
+    $res= $this->handle($fixture);
+
+    Assert::equals('strict-origin', $res->headers()['Referrer-Policy']);
+  }
+
+  #[Test]
+  public function add_content_security_policy() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $fixture->security()->csp([
+      'default-src' => '"none"',
+      'script-src'  => ['"self"', '"nonce-1234"', 'https://example.com']
+    ]);
+    $res= $this->handle($fixture);
+
+    Assert::equals(
+      'default-src "none"; script-src "self" "nonce-1234" https://example.com',
+      $res->headers()['Content-Security-Policy']
+    );
+  }
+
+  #[Test]
+  public function add_report_only_content_security_policy() {
+    $fixture= new Frontend(new Home(), $this->templates);
+    $fixture->security()->csp(['default-src' => '"none"'], true);
+    $res= $this->handle($fixture);
+
+    Assert::equals(
+      'default-src "none"',
+      $res->headers()['Content-Security-Policy-Report-Only']
+    );
+  }
+
+  #[Test]
+  public function content_security_policy_generates_and_passes_nonce() {
+    $fixture= new Frontend(new Home(), newinstance(Templates::class, [], [
+      'write' => function($template, $context= [], $out) use(&$result) {
+        $result= $context;
+      }
+    ]));
+    $fixture->security()->csp(['script-src' => '"nonce-{{nonce}}"']);
+    $res= $this->handle($fixture);
+
+    preg_match('/script-src "nonce-([^"]+)"/', $res->headers()['Content-Security-Policy'], $m);
+    Assert::equals(32, strlen($m[1]), 'nonce must consist of 32 bytes "'.$m[1].'"');
+    Assert::equals($m[1], $result['nonce'] ?? null, 'nonce must appear in content');
+  }
+
+  #[Test]
+  public function nonce_generated_is_unique_for_every_request() {
+    $fixture= new Frontend(new Home(), newinstance(Templates::class, [], [
+      'write' => function($template, $context= [], $out) use(&$result) {
+        $result= $context;
+      }
+    ]));
+    $fixture->security()->csp(['script-src' => '"nonce-{{nonce}}"']);
+
+    Assert::notEquals(
+      $this->handle($fixture)->headers()['Content-Security-Policy'],
+      $this->handle($fixture)->headers()['Content-Security-Policy']
+    );
+  }
+}


### PR DESCRIPTION
## What this pull request does

Implements #30 and sets `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` to sensible default values and allows specifying a `Content-Security-Policy` (including Report-Only mode).

```php
use web\frontend\{Frontend, Security};

$frontend= (new Frontend($delegates, $templates))
  ->enacting((new Security())
    ->framing('SAMEORIGIN')       // X-Frame-Options, defaults to "DENY"
    ->referrers('strict-origin')  // Referrer-Policy, defaults to "no-referrer-when-downgrade"
    ->csp([                       // Content-Security-Policy, defaults to none
      'default-src' => "'none'",
      'script-src'  => "'self' 'nonce-{{nonce}}' https://example.com",
      // etcetera
    ])
  )
;
```

## CSP

Content Security Policy is quite specific to what you are doing on your site, so no default value is supplied. However, using `default-src 'self'; script-src 'self' 'nonce-{{nonce}}'; style-src 'self' 'nonce-{{nonce}}; img-src 'self' https:` and then supplying `nonce` attributes on your `<script>` and `<style>` tags is maybe a good starting point as well as replacing `on...`-attributes with `addEventListener()`.

**If we introduce a default CSP, this would be done in a separate major release!**

*See also https://content-security-policy.com/, https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP and https://scotthelme.co.uk/content-security-policy-an-introduction/*

## Example

With **no code changed** (*that is, just using the defaults*), the rating from https://securityheaders.com/ changes as follows:

### Before

![Screenshot of rating before](https://user-images.githubusercontent.com/696742/198838385-34fd8b8e-ce86-41aa-9549-3f3bb87f3024.png)

### After

![Screenshot of rating after](https://user-images.githubusercontent.com/696742/198838477-e1eec4b0-184a-4a98-9c8c-b83c7eb9b99d.png)

If we were to define a content security policy, we could get an `A` rating.

## BC break

This pull request doesn't break any code, but site's behavior will be different:

* If you would like to embed your site in an `<iframe>`, you will have to set the `X-Frame-Options` header (either globally or on the embedding resource)
* If other non-secure sites rely on your site sending them a HTTP referrer, this will be broken. To restore this behavior, you will have to set `Referrer-Policy` to *unsafe-url*   