### PR TITLE
Remove error handling constructor parameter

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -11,7 +11,8 @@ use web\{Error, Handler};
  * @test  web.frontend.unittest.CSRFTokenTest
  */
 class Frontend implements Handler {
-  private $delegates, $templates, $errors;
+  private $delegates, $templates;
+  private $errors= null;
   public $globals;
 
   /**
@@ -20,13 +21,11 @@ class Frontend implements Handler {
    * @param  web.frontend.Delegates|object $arg
    * @param  web.frontend.Templates $templates
    * @param  [:var] $globals
-   * @param  ?web.frontend.Errors $handling
    */
-  public function __construct($arg, Templates $templates, $globals= [], Errors $handling= null) {
+  public function __construct($arg, Templates $templates, $globals= []) {
     $this->delegates= $arg instanceof Delegates ? $arg : new MethodsIn($arg);
     $this->templates= $templates;
     $this->globals= is_string($globals) ? ['base' => rtrim($globals, '/')] : $globals;
-    $this->errors= $handling;
   }
 
   /** Overwrites error handler */

--- a/src/test/php/web/frontend/unittest/FrontendTest.class.php
+++ b/src/test/php/web/frontend/unittest/FrontendTest.class.php
@@ -47,12 +47,6 @@ class FrontendTest {
   }
 
   #[Test]
-  public function passed_exception_handling() {
-    $h= new Exceptions();
-    Assert::equals($h, (new Frontend(new Users(), $this->templates, [], $h))->errors());
-  }
-
-  #[Test]
   public function changed_exception_handling() {
     $h= new Exceptions();
     Assert::equals($h, (new Frontend(new Users(), $this->templates))->handling($h)->errors());


### PR DESCRIPTION
Keeps API slim - use the fluent style interface (*[as advertised in README](https://github.com/xp-forge/frontend#error-handling)*) for changing the error handler instead.

⚠️ This is a BC break and will require a new major version (4.0.0 at the time of writing)!