### PR TITLE
Handle HEAD requests via GET unless explicitely handled

### DIFF
--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -337,4 +337,16 @@ class HandlingTest extends TestCase {
     $this->handle($fixture, 'GET', '/blogs/stats');
     $this->assertContext(['request' => ['params' => []]], $result);
   }
+
+  #[Test]
+  public function head_request_handled_by_get_but_does_not_send_response() {
+    $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
+      'write' => function($template, $context= [], $out) {
+        $out->write('Test');
+      }
+    ]));
+
+    $res= $this->handle($fixture, 'HEAD', '/users/1');
+    $this->assertEquals("\r\n\r\n", strstr($res->output()->bytes(), "\r\n\r\n"));
+  }
 }

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -339,7 +339,33 @@ class HandlingTest extends TestCase {
   }
 
   #[Test]
-  public function head_request_handled_by_get_but_does_not_send_response() {
+  public function head_handled_by_get() {
+    $handler= newinstance(Users::class, [], [
+      '#[Get] handler' => function() use(&$invoked) { return $invoked= true; }
+    ]);
+    $fixture= new Frontend($handler, new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    });
+
+    $this->handle($fixture, 'HEAD', '/');
+    $this->assertTrue($invoked);
+  }
+
+  #[Test]
+  public function head_explictely_defined() {
+    $handler= newinstance(Users::class, [], [
+      '#[Head] handler' => function() use(&$invoked) { return $invoked= true; }
+    ]);
+    $fixture= new Frontend($handler, new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    });
+
+    $this->handle($fixture, 'HEAD', '/');
+    $this->assertTrue($invoked);
+  }
+
+  #[Test]
+  public function head_request_does_not_send_response() {
     $fixture= new Frontend(new Users(), newinstance(Templates::class, [], [
       'write' => function($template, $context= [], $out) {
         $out->write('Test');


### PR DESCRIPTION
Implements #34 

Deprecates workaround with setting `$view->context= null` as seen in the example there!