### PR TITLE
Migrate to new reflection library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/reflection": "^2.0",
     "xp-forge/web": "^3.0 | ^2.9",
     "xp-forge/json": "^5.0 | ^4.0",
     "php": ">=7.0.0"

--- a/src/main/php/web/frontend/Delegate.class.php
+++ b/src/main/php/web/frontend/Delegate.class.php
@@ -82,7 +82,7 @@ class Delegate {
    *
    * @param  var[] $args
    * @return web.frontend.View
-   * @throws lang.reflect.TargetInvocationException
+   * @throws lang.reflection.TargetException
    */
   public function invoke($args) {
     $result= $this->method->invoke($this->instance, $args);

--- a/src/main/php/web/frontend/Delegate.class.php
+++ b/src/main/php/web/frontend/Delegate.class.php
@@ -55,9 +55,9 @@ class Delegate {
       foreach ($this->method->parameters() as $param) {
 
         // Check for parameter annotations...
-        foreach ($param->annotations() as $from => $value) {
-          $source= self::$SOURCES[$from] ?? self::$SOURCES['default'];
-          $name= $value->argument(0) ?? $param->name();
+        foreach ($param->annotations() as $annotation) {
+          $source= self::$SOURCES[$annotation->name()] ?? self::$SOURCES['default'];
+          $name= $annotation->argument(0) ?? $param->name();
 
           if ($param->optional()) {
             $this->parameters[$name]= function($req, $name) use($source, $param) {

--- a/src/main/php/web/frontend/Delegates.class.php
+++ b/src/main/php/web/frontend/Delegates.class.php
@@ -1,10 +1,8 @@
 <?php namespace web\frontend;
 
-use lang\IllegalArgumentException;
+use lang\{IllegalArgumentException, Reflection};
 
-/**
- * Matches request and routes to correct delegate
- */
+/** Matches request and routes to correct delegate */
 class Delegates {
   public $patterns= [];
 
@@ -22,9 +20,10 @@ class Delegates {
     }
 
     $base= rtrim($base, '/');
-    foreach (typeof($instance)->getMethods() as $method) {
-      $name= $method->getName();
-      foreach ($method->getAnnotations() as $verb => $segment) {
+    foreach (Reflection::type($instance)->methods() as $method) {
+      $name= $method->name();
+      foreach ($method->annotations() as $verb => $annotation) {
+        $segment= $annotation->argument(0);
         $pattern= preg_replace(
           ['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'],
           ['(?<$1>$2)', '(?<$1>[^/]+)'],

--- a/src/main/php/web/frontend/Delegates.class.php
+++ b/src/main/php/web/frontend/Delegates.class.php
@@ -22,14 +22,14 @@ class Delegates {
     $base= rtrim($base, '/');
     foreach (Reflection::type($instance)->methods() as $method) {
       $name= $method->name();
-      foreach ($method->annotations() as $verb => $annotation) {
+      foreach ($method->annotations() as $annotation) {
         $segment= $annotation->argument(0);
         $pattern= preg_replace(
           ['/\{([^:}]+):([^}]+)\}/', '/\{([^}]+)\}/'],
           ['(?<$1>$2)', '(?<$1>[^/]+)'],
           $base.('/' === $segment || null === $segment ? '/?' : $segment)
         );
-        $this->patterns['#'.$verb.$pattern.'$#']= new Delegate($instance, $method);
+        $this->patterns['#'.$annotation->name().$pattern.'$#']= new Delegate($instance, $method);
       }
     }
     return $this;

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -1,6 +1,6 @@
 <?php namespace web\frontend;
 
-use lang\reflect\TargetInvocationException;
+use lang\reflection\TargetException;
 use web\{Error, Handler, Request};
 
 /**
@@ -98,7 +98,7 @@ class Frontend implements Handler {
       }
 
       return $delegate->invoke($args);
-    } catch (TargetInvocationException $e) {
+    } catch (TargetException $e) {
       return $this->errors()->handle($e->getCause());
     }
   }

--- a/src/main/php/web/frontend/HandlersIn.class.php
+++ b/src/main/php/web/frontend/HandlersIn.class.php
@@ -1,26 +1,28 @@
 <?php namespace web\frontend;
 
-use lang\reflect\Package;
+use lang\reflection\Package;
 
 /**
- * Creates routing based on classes annotated with `@handler` in a
- * given package.
+ * Creates routing based on classes annotated with the `Handler` annotation
+ * in a given package.
  *
- * @test  xp://web.frontend.unittest.HandlersInTest
+ * @test  web.frontend.unittest.HandlersInTest
  */
 class HandlersIn extends Delegates {
 
   /**
    * Creates this delegates instance
    *
-   * @param  lang.reflect.Package|string $package
+   * @param  lang.reflection.Package|string $package
    * @param  function(lang.XPClass): object $new Optional function to create instances
    */
   public function __construct($package, $new= null) {
-    $p= $package instanceof Package ? $package : Package::forName($package);
-    foreach ($p->getClasses() as $class) {
-      if ($class->hasAnnotation('handler')) {
-        $this->with($new ? $new($class) : $class->newInstance(), (string)$class->getAnnotation('handler'));
+    $p= $package instanceof Package ? $package : new Package($package);
+    foreach ($p->types() as $type) {
+      if ($handler= $type->annotation(Handler::class)) {
+        $this->with($new ? $new($type) : $type->newInstance(), (string)$handler->argument(0));
+      } else {
+        throw new \lang\IllegalStateException('Not a handler: '.$type->name());
       }
     }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });

--- a/src/main/php/web/frontend/MethodsIn.class.php
+++ b/src/main/php/web/frontend/MethodsIn.class.php
@@ -1,20 +1,22 @@
 <?php namespace web\frontend;
 
-use lang\IllegalArgumentException;
+use lang\{IllegalArgumentException, Reflection};
 
-/**
- * Creates routing based on a given instance
- */
+/** Creates routing based on a given instance */
 class MethodsIn extends Delegates {
 
   /** @param object $instance */
   public function __construct($instance) {
-    $type= typeof($instance);
     if (!is_object($instance)) {
-      throw new IllegalArgumentException('Expected an object, have '.$type);
+      throw new IllegalArgumentException('Expected an object, have '.typeof($instance));
     }
 
-    $this->with($instance, $type->hasAnnotation('handler') ? (string)$type->getAnnotation('handler') : '/');
+    $type= Reflection::type($instance);
+    if ($handler= $type->annotation(Handler::class)) {
+      $this->with($instance, (string)$handler->argument(0));
+    } else {
+      $this->with($instance, '/');
+    }
     uksort($this->patterns, function($a, $b) { return strlen($b) - strlen($a); });
   }
 }

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -1,25 +1,25 @@
 <?php namespace web\frontend\unittest;
 
-use lang\reflect\Package;
-use test\Assert;
-use test\{Test, TestCase};
+use lang\reflection\Package;
+use test\{Assert, Test};
 use web\frontend\HandlersIn;
 
 class HandlersInTest {
+  const PACKAGE= 'web.frontend.unittest.actions';
 
   #[Test]
   public function can_create_with_string() {
-    new HandlersIn('web.frontend.unittest.actions');
+    new HandlersIn(self::PACKAGE);
   }
 
   #[Test]
   public function can_create_with_package() {
-    new HandlersIn(Package::forName('web.frontend.unittest.actions'));
+    new HandlersIn(new Package(self::PACKAGE));
   }
 
   #[Test]
   public function patterns_sorted_by_length() {
-    $delegates= new HandlersIn('web.frontend.unittest.actions');
+    $delegates= new HandlersIn(self::PACKAGE);
     Assert::equals(
       [
         '#get/blogs/(?<category>[^/]+)/(?<id>[0-9]+)$#',


### PR DESCRIPTION
This pull request migrates the code to use `xp-framework/reflection`. As this changes the API, we will releases this as a major release, 5.0.0 at the time of writing.

## Performance

No measurable impact.

### Before

```bash
$ xp test src/test/php
# ...
Test cases:  156 succeeded
Memory used: 3847.27 kB (3901.40 kB peak)
Time taken:  0.078 seconds (0.159 seconds overall)
```

### After

```bash
$ xp test src/test/php
# ...
Test cases:  156 succeeded
Memory used: 3639.90 kB (3694.02 kB peak)
Time taken:  0.079 seconds (0.157 seconds overall)
```

## See also

* https://github.com/xp-framework/rfc/issues/338
* https://github.com/xp-framework/core/pull/332