### PR TITLE
Support multiple sources in web.frontend.AssetsFrom

### DIFF
--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -113,10 +113,11 @@ class AssetsFrom extends FilesFrom {
    */
   public function handle($request, $response) {
     $path= $request->uri()->path();
+    $accept= $this->negotiate($request->header('Accept-Encoding', ''));
     foreach ($this->sources as $source) {
 
       // Check all variants in Accept-Encoding, including `*`
-      foreach ($this->negotiate($request->header('Accept-Encoding', '')) as $encoding => $q) {
+      foreach ($accept as $encoding => $q) {
         $target= new Path($source, $path.(self::ENCODINGS[$encoding] ?? '*'));
         if ($target->exists() && $target->isFile()) {
           $response->header('Vary', 'Accept-Encoding');

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -113,7 +113,7 @@ class AssetsFrom extends FilesFrom {
    */
   public function handle($request, $response) {
     $path= $request->uri()->path();
-    $accept= $this->negotiate($request->header('Accept-Encoding', ''));
+    $accept= $this->negotiate($request->header('Accept-Encoding') ?? '');
     foreach ($this->sources as $source) {
 
       // Check all variants in Accept-Encoding, including `*`

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -25,11 +25,14 @@ class AssetsFrom extends FilesFrom {
     '*'        => ''
   ];
 
+  private $sources= [];
   private $preference;
 
-  /** @param io.Path|io.Folder|string $path */
-  public function __construct($path) {
-    parent::__construct($path);
+  /** @param io.Path|io.Folder|string|io.Path[]|io.Folder[]|string[] $sources */
+  public function __construct($sources) {
+    foreach (is_array($sources) ? $sources : [$sources] as $source) {
+      $this->sources[]= $source instanceof Path ? $source : new Path($source);
+    }
     $this->preferring(self::PREFERENCE);
   }
 
@@ -109,20 +112,21 @@ class AssetsFrom extends FilesFrom {
    */
   public function handle($request, $response) {
     $path= $request->uri()->path();
-    $base= $this->path();
+    foreach ($this->sources as $source) {
 
-    // Check all variants in Accept-Encoding, including `*`
-    foreach ($this->negotiate($request->header('Accept-Encoding', '')) as $encoding => $q) {
-      $target= new Path($base, $path.(self::ENCODINGS[$encoding] ?? '*'));
-      if ($target->exists() && $target->isFile()) {
-        $response->header('Vary', 'Accept-Encoding');
-        '*' === $encoding || $response->header('Content-Encoding', $encoding);
+      // Check all variants in Accept-Encoding, including `*`
+      foreach ($this->negotiate($request->header('Accept-Encoding', '')) as $encoding => $q) {
+        $target= new Path($source, $path.(self::ENCODINGS[$encoding] ?? '*'));
+        if ($target->exists() && $target->isFile()) {
+          $response->header('Vary', 'Accept-Encoding');
+          '*' === $encoding || $response->header('Content-Encoding', $encoding);
 
-        return $this->serve($request, $response, $target->asFile(), $this->mime($path));
+          return $this->serve($request, $response, $target->asFile(), $this->mime($path));
+        }
       }
     }
 
-    // No target exists, generate a 404
+    // Target does not exist in any of the sources, generate a 404
     return $this->serve($request, $response, null);
   }
 }

--- a/src/main/php/web/frontend/AssetsFrom.class.php
+++ b/src/main/php/web/frontend/AssetsFrom.class.php
@@ -30,10 +30,11 @@ class AssetsFrom extends FilesFrom {
 
   /** @param io.Path|io.Folder|string|io.Path[]|io.Folder[]|string[] $sources */
   public function __construct($sources) {
+    $this->preferring(self::PREFERENCE);
     foreach (is_array($sources) ? $sources : [$sources] as $source) {
       $this->sources[]= $source instanceof Path ? $source : new Path($source);
     }
-    $this->preferring(self::PREFERENCE);
+    parent::__construct($this->sources[0] ?? '.');
   }
 
   /**

--- a/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
+++ b/src/test/php/web/frontend/unittest/AssetsFromTest.class.php
@@ -181,6 +181,28 @@ class AssetsFromTest {
     Assert::equals(404, $res->status());
   }
 
+  #[Test]
+  public function supports_multiple_sources() {
+    $local= $this->folderWith(['fixture.css' => '/* Local */']);
+    $module= $this->folderWith(['module.css' => '/* Module */']);
+
+    $res= $this->serve(new AssetsFrom([$local, $module]), '/module.css');
+
+    Assert::equals(200, $res->status());
+    $this->assertFile('/* Module */', $res);
+  }
+
+  #[Test]
+  public function loads_file_from_first_source() {
+    $local= $this->folderWith(['fixture.css' => '/* Local */']);
+    $module= $this->folderWith(['fixture.css' => '/* Module */']);
+
+    $res= $this->serve(new AssetsFrom([$local, $module]), '/fixture.css');
+
+    Assert::equals(200, $res->status());
+    $this->assertFile('/* Local */', $res);
+  }
+
   #[Test, Values([['fixture.css.gz', 'gzip'], ['fixture.css.br', 'br'], ['fixture.css.dfl', 'deflate'], ['fixture.css.bz2', 'bzip2']])]
   public function serves_compressed_when_file_present($file, $encoding) {
     $files= [$file => self::COMPRESSED];


### PR DESCRIPTION
This pull request adds the possibility to pass an array of paths which will be searched for the requested asset. The first path to provide the asset is selected, the file being served from there.

```php
// Single source
$assets= new AssetsFrom($this->environment->path('src/main/webapp'));

// Multiple sources
$assets= new AssetsFrom([
  $this->environment->path('src/main/webapp'),
  $this->environment->path('vendor/example/layout-lib/src/main/webapp'),
]);
```
