### PR TITLE
Support X-Csrf-Token header

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -87,7 +87,7 @@ class Frontend implements Handler {
     }
 
     // Verify CSRF token for anything which is not a GET or HEAD request
-    $token= $req->param('token') ?? $req->header('X-CSRF-Token');
+    $token= $req->param('token') ?? $req->header('X-Csrf-Token');
     if (!isset($CSRF_EXEMPT[strtolower($req->method())]) && $req->value('token') !== $token) {
       return $this->errors()->handle(new Error(403, 'Incorrect CSRF token for '.$delegate->name()));
     }

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -87,7 +87,8 @@ class Frontend implements Handler {
     }
 
     // Verify CSRF token for anything which is not a GET or HEAD request
-    if (!isset($CSRF_EXEMPT[strtolower($req->method())]) && $req->value('token') !== $req->param('token')) {
+    $token= $req->param('token') ?? $req->header('X-CSRF-Token');
+    if (!isset($CSRF_EXEMPT[strtolower($req->method())]) && $req->value('token') !== $token) {
       return $this->errors()->handle(new Error(403, 'Incorrect CSRF token for '.$delegate->name()));
     }
 

--- a/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
+++ b/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
@@ -24,11 +24,12 @@ class CSRFTokenTest {
    * @param  string $method
    * @param  string $uri
    * @param  ?string $payload
+   * @param  [:string] $headers
    * @return void
    * @throws web.Error
    */
-  private function execute($method, $uri, $payload= null) {
-    $headers= $payload ? ['Content-Type' => 'application/x-www-form-urlencoded'] : [];
+  private function execute($method, $uri, $payload= null, $headers= []) {
+    $payload && $headers['Content-Type']= 'application/x-www-form-urlencoded';
 
     $req= new Request(new TestInput($method, $uri, $headers, (string)$payload));
     $res= new Response(new TestOutput());
@@ -37,8 +38,13 @@ class CSRFTokenTest {
   }
 
   #[Test]
-  public function validated() {
+  public function validated_as_part_of_payload() {
     $this->execute('POST', '/users', 'token='.self::TOKEN.'&username=test');
+  }
+
+  #[Test]
+  public function validated_as_header() {
+    $this->execute('POST', '/users', 'username=test', ['X-CSRF-Token' => self::TOKEN]);
   }
 
   #[Test]

--- a/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
+++ b/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
@@ -44,7 +44,7 @@ class CSRFTokenTest {
 
   #[Test]
   public function validated_as_header() {
-    $this->execute('POST', '/users', 'username=test', ['X-CSRF-Token' => self::TOKEN]);
+    $this->execute('POST', '/users', 'username=test', ['X-Csrf-Token' => self::TOKEN]);
   }
 
   #[Test]


### PR DESCRIPTION
For AJAX requests, it may be easier to send a header along instead of merging the CSRF token into the payload.

* https://en.wikipedia.org/wiki/Cross-site_request_forgery
* https://stackoverflow.com/questions/30149023/how-to-include-the-csrf-token-in-the-headers-in-dropzone-upload-request
* https://htmx.org/events/#htmx:configRequest