### PR TITLE
Add support for special `_method` field to overwrite POST for routing

### DIFF
--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -116,7 +116,7 @@ class Frontend implements Handler {
     static $NOT_FOUND= [null];
 
     // Handle HEAD requests with GET unless explicitely specified
-    $method= strtolower($req->method());
+    $method= strtolower($req->param('_method') ?? $req->method());
     $path= $req->uri()->path();
     if ('head' === $method) {
       $target= $this->delegates->target($method, $path) ?? $this->delegates->target('get', $path) ?? $NOT_FOUND;

--- a/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
+++ b/src/test/php/web/frontend/unittest/CSRFTokenTest.class.php
@@ -58,6 +58,11 @@ class CSRFTokenTest {
   }
 
   #[Test, Expect(class: Error::class, message: '/Incorrect CSRF token for .+Users::create/')]
+  public function raises_error_when_empty() {
+    $this->execute('POST', '/users', 'token=&username=test');
+  }
+
+  #[Test, Expect(class: Error::class, message: '/Incorrect CSRF token for .+Users::create/')]
   public function raises_error_when_incorrect() {
     $this->execute('POST', '/users', 'token=INCORRECT&username=test');
   }

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -25,6 +25,7 @@ class HandlersInTest {
         '#get/blogs/(?<category>[^/]+)/(?<id>[0-9]+)$#',
         '#get/oauth/(?<tenant>[^/]+)/select/?$#',
         '#get/users/(?<id>[^/]+)/avatar$#',
+        '#delete/users/(?<id>[^/]+)$#',
         '#get/users/(?<id>[^/]+)$#',
         '#get/blogs/stats$#',
         '#get/blogs/?$#',

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -140,6 +140,28 @@ class HandlingTest {
     );
   }
 
+  #[Test]
+  public function delete() {
+    $fixture= new Frontend(new Users(), new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    });
+
+    $res= $this->handle($fixture, 'DELETE', '/users/1000');
+    Assert::equals(302, $res->status());
+    Assert::equals('/users?deleted=1000', $res->headers()['Location']);
+  }
+
+  #[Test]
+  public function delete_via_special_method_field() {
+    $fixture= new Frontend(new Users(), new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    });
+
+    $res= $this->handle($fixture, 'POST', '/users/1000', [], '_method=DELETE');
+    Assert::equals(302, $res->status());
+    Assert::equals('/users?deleted=1000', $res->headers()['Location']);
+  }
+
   #[Test, Expect(class: Error::class, message: '/Cannot route PATCH requests to .+/')]
   public function unsupported_route() {
     $fixture= new Frontend(new Users(), new class() implements Templates {

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -152,7 +152,7 @@ class HandlingTest {
   }
 
   #[Test]
-  public function delete_via_special_method_field() {
+  public function special_method_field_overwrites_post_method() {
     $fixture= new Frontend(new Users(), new class() implements Templates {
       public function write($template, $context, $out) { /* NOOP */ }
     });
@@ -160,6 +160,16 @@ class HandlingTest {
     $res= $this->handle($fixture, 'POST', '/users/1000', [], '_method=DELETE');
     Assert::equals(302, $res->status());
     Assert::equals('/users?deleted=1000', $res->headers()['Location']);
+  }
+
+  #[Test]
+  public function special_method_field_cannot_be_used_for_get() {
+    $fixture= new Frontend(new Users(), new class() implements Templates {
+      public function write($template, $context, $out) { /* NOOP */ }
+    });
+
+    $res= $this->handle($fixture, 'GET', '/users/1000?_method=DELETE');
+    Assert::equals(404, $res->status());
   }
 
   #[Test, Expect(class: Error::class, message: '/Cannot route PATCH requests to .+/')]

--- a/src/test/php/web/frontend/unittest/MethodsInTest.class.php
+++ b/src/test/php/web/frontend/unittest/MethodsInTest.class.php
@@ -18,6 +18,7 @@ class MethodsInTest {
     Assert::equals(
       [
         '#get/users/(?<id>[^/]+)/avatar$#',
+        '#delete/users/(?<id>[^/]+)$#',
         '#get/users/(?<id>[^/]+)$#',
         '#post/users$#',
         '#get/users$#',

--- a/src/test/php/web/frontend/unittest/actions/Users.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Users.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\frontend\unittest\actions;
 
 use web\Error;
-use web\frontend\{Get, Handler, Param, Post, View};
+use web\frontend\{Delete, Get, Handler, Param, Post, View};
 
 #[Handler]
 class Users {
@@ -46,6 +46,12 @@ class Users {
     $id= sizeof($this->list) + 1;
     $this->list[]= ['id' => $id, 'name' => $username];
     return ['created' => $id];
+  }
+
+  #[Delete('/users/{id}')]
+  public function delete($id) {
+    unset($this->list[$id]);
+    return View::redirect('/users?deleted='.urlencode($id));
   }
 
   #[Get('/users/{id}/avatar')]


### PR DESCRIPTION
HTML forms do not support anything other than `GET` and `POST`. The value sent with the `_method` field will be used as the HTTP request method instead of **POST**:

```html
<form action="/example" method="POST">
  <input type="hidden" name="_method" value="PUT">
  <!-- Rest of form -->
</form>
```

This will use `PUT` for the server-side routing instead of `POST`. The method inside the request object will stay the same, though.

The name was chosen as it is a pseudo-standard amongst various frameworks.

* * *

See also:

* https://laravel.com/docs/10.x/routing#form-method-spoofing
* https://codeigniter.com/user_guide/incoming/methodspoofing.html
* https://coldbox.ortusbooks.com/the-basics/routing/http-method-spoofing
* https://docs.adonisjs.com/guides/request#form-method-spoofing
* https://www.alexedwards.net/blog/http-method-spoofing
* https://github.com/advisories/GHSA-j4mm-7pj3-jf7v