### PR TITLE
Support compression when downloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/reflection": "^2.0",
     "xp-forge/web": "^3.0 | ^2.9",
+    "xp-forge/compression": "^1.0",
     "xp-forge/json": "^5.0 | ^4.0",
     "php": ">=7.0.0"
   },

--- a/src/test/php/web/frontend/unittest/bundler/FetchTest.class.php
+++ b/src/test/php/web/frontend/unittest/bundler/FetchTest.class.php
@@ -1,0 +1,137 @@
+<?php namespace web\frontend\unittest\bundler;
+
+use io\{Files, Folder};
+use lang\{Environment, IllegalArgumentException};
+use test\verify\Runtime;
+use test\{After, Assert, Before, Expect, Test};
+use util\URI;
+use xp\frontend\Fetch;
+
+class FetchTest {
+  const ETAG= '"17e1-5626f327566c0"';
+
+  private $tempDir;
+
+  /** Creates a new random URI */
+  private function randomUri(): URI {
+    return new URI('https://example.com/?id='.uniqid());
+  }
+
+  #[Before]
+  public function tempDir() {
+    $this->tempDir= new Folder(Environment::tempDir(), uniqid());
+    $this->tempDir->create(0777);
+  }
+
+  #[Test]
+  public function can_create() {
+    new Fetch($this->tempDir, false);
+  }
+
+  #[Test]
+  public function fetches_from_and_caches_revalidating() {
+    $uri= $this->randomUri();
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(200, ['Content-Length' => 4, 'ETag' => self::ETAG], 'Test');
+    });
+
+    $response= $fixture->get($uri, [], false);
+
+    Assert::false($response->cached());
+    Assert::equals('Test', $response->read());
+    Assert::true($fixture->cache($uri)->exists());
+  }
+
+  #[Test]
+  public function uses_cache() {
+    $uri= $this->randomUri();
+    $fixture= new Fetch($this->tempDir, false);
+
+    Files::write($fixture->cache($uri), self::ETAG."\nTest");
+    $response= $fixture->get($uri, [], false);
+
+    Assert::true($response->cached());
+    Assert::equals('Test', $response->read());
+  }
+
+  #[Test]
+  public function revalidates_cache() {
+    $uri= $this->randomUri();
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(200, ['Content-Length' => 4, 'ETag' => self::ETAG], 'Test');
+    });
+
+    Files::write($fixture->cache($uri), self::ETAG."\nTest");
+    $response= $fixture->get($uri, [], true);
+
+    Assert::false($response->cached());
+    Assert::equals('Test', $response->read());
+  }
+
+  #[Test]
+  public function uses_cache_if_not_modified() {
+    $uri= $this->randomUri();
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(304, ['ETag' => self::ETAG]);
+    });
+
+    Files::write($fixture->cache($uri), self::ETAG."\nTest");
+    $response= $fixture->get($uri, [], true);
+
+    Assert::true($response->cached());
+    Assert::equals('Test', $response->read());
+  }
+
+  #[Test, Expect(class: IllegalArgumentException::class, message: '404 Test')]
+  public function throws_on_not_found() {
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(404);
+    });
+
+    $fixture->get($this->randomUri(), [], true);
+  }
+
+  #[Test]
+  public function handles_identity_encoding() {
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(
+        200,
+        ['Content-Length' => 12, 'Content-Encoding' => 'identity'],
+        'Test'
+      );
+    });
+
+    Assert::equals('Test', $fixture->get($this->randomUri(), [], false)->read());
+  }
+
+  #[Test, Runtime(extensions: ['zlib'])]
+  public function handles_gzip_compression() {
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(
+        200,
+        ['Content-Length' => 12, 'Content-Encoding' => 'gzip'],
+        gzencode('Test')
+      );
+    });
+
+    Assert::equals('Test', $fixture->get($this->randomUri(), [], false)->read());
+  }
+
+  #[Test, Runtime(extensions: ['brotli'])]
+  public function handles_brotli_compression() {
+    $fixture= (new Fetch($this->tempDir, false))->connecting(function($uri) {
+      return new TestConnection(
+        200,
+        ['Content-Length' => 12, 'Content-Encoding' => 'br'],
+        brotli_compress('Test')
+      );
+    });
+
+    Assert::equals('Test', $fixture->get($this->randomUri(), [], false)->read());
+  }
+
+  #[After]
+  public function cleanUp() {
+    $this->tempDir->unlink();
+  }
+}

--- a/src/test/php/web/frontend/unittest/bundler/TestConnection.class.php
+++ b/src/test/php/web/frontend/unittest/bundler/TestConnection.class.php
@@ -1,0 +1,22 @@
+<?php namespace web\frontend\unittest\bundler;
+
+use io\streams\MemoryInputStream;
+use peer\http\{HttpConnection, HttpRequest, HttpResponse};
+
+class TestConnection extends HttpConnection {
+  private $response;
+
+  public function __construct($status, $headers= [], $payload= '') {
+    parent::__construct('http://test');
+
+    $this->response= "HTTP/1.1 {$status} Test\r\n";
+    foreach ($headers as $name => $value) {
+      $this->response.= $name.': '.$value."\r\n";
+    }
+    $this->response.= "\r\n{$payload}";
+  }
+
+  public function send(HttpRequest $request) {
+    return new HttpResponse(new MemoryInputStream($this->response));
+  }
+}


### PR DESCRIPTION
This makes use of the https://github.com/xp-forge/compression library and improves the download speed.

## Speed
*Note: This is on an 16MBit DSL line (yes, I know it's 2023, looking at you, Deutsche Telekom 😊!)*

Before:
```bash
$ xp bundle -f
Resolving package versions
  - Resolving npm/ol (^7.1 => 7.5.2)
  - Resolving Overpass (fonts)
  - Resolving . (local .)
Generating vendor bundle (dependencies: 3)
> static\vendor.css: 6.29 kB
> static\vendor.css.gz: 1.52 kB
> static\vendor.css.br: 1.31 kB
> static\vendor.js: 755.80 kB
> static\vendor.js.gz: 204.90 kB
> static\vendor.js.br: 167.10 kB
Bundle operations: 1 bundle(s) created in 3.774 seconds using 5716.57 kB memory
```

After:
```bash
$ xp bundle -f
Resolving package versions
  - Resolving npm/ol (^7.1 => 7.5.2)
  - Resolving Overpass (fonts)
  - Resolving . (local .)
Generating vendor bundle (dependencies: 3)
> static\vendor.css: 6.29 kB
> static\vendor.css.gz: 1.52 kB
> static\vendor.css.br: 1.31 kB
> static\vendor.js: 755.80 kB
> static\vendor.js.gz: 204.90 kB
> static\vendor.js.br: 167.10 kB
Bundle operations: 1 bundle(s) created in 3.420 seconds using 5794.55 kB memory
```

**About 300ms, not a huge improvement, but I'll take it 🙂!**