### PR TITLE
Allow specifying template and fragment via `View::named()`

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -18,11 +18,13 @@ class View {
   /**
    * Sets template to use
    *
-   * @param  string $template
+   * @param  string $name
    * @return self
    */
-  public static function named($template) {
+  public static function named($name) {
+    sscanf($name, "%[^#]#%[^\r]", $template, $fragment);
     $self= new self($template);
+    $self->fragment= $fragment;
     $self->headers['Content-Type']= 'text/html; charset='.\xp::ENCODING;
     return $self;
   }

--- a/src/test/php/web/frontend/unittest/ViewTest.class.php
+++ b/src/test/php/web/frontend/unittest/ViewTest.class.php
@@ -21,6 +21,13 @@ class ViewTest {
   }
 
   #[Test]
+  public function template_and_fragment_separated_with_hash() {
+    $view= View::named('test#inline');
+    Assert::equals('test', $view->template);
+    Assert::equals('inline', $view->fragment);
+  }
+
+  #[Test]
   public function default_status() {
     Assert::equals(200, View::named('test')->status);
   }


### PR DESCRIPTION
```php
// Fluent syntax
View::named('index')->fragment('inline');

// Shorthand of the above
View::named('index#inline');
```

See https://youtu.be/akd7u69k27k?t=1410