### PR TITLE
Allow specifying status code in `View::redirect()`

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -31,11 +31,12 @@ class View {
    * Redirects to another URL
    *
    * @param  string|util.URI $uri
+   * @param  int $status Defaults to 302
    * @return self
    */
-  public static function redirect($url) {
+  public static function redirect($url, $status= 302) {
     $self= new self(null);
-    $self->status= 302;
+    $self->status= $status;
     $self->headers['Location']= $url;
     $self->headers['Content-Length']= 0;
     $self->stream= false;

--- a/src/test/php/web/frontend/unittest/ViewTest.class.php
+++ b/src/test/php/web/frontend/unittest/ViewTest.class.php
@@ -55,6 +55,14 @@ class ViewTest {
   }
 
   #[Test]
+  public function redirect_using_307() {
+    $redirect= View::redirect('http://test', 307);
+
+    Assert::equals(307, $redirect->status);
+    Assert::equals('http://test', $redirect->headers['Location']);
+  }
+
+  #[Test]
   public function error_sets_template_and_status() {
     $redirect= View::error(404);
 


### PR DESCRIPTION
Example:

```php
// Uses default status code 302
View::redirect('https://example.com');

// Uses "Temporary Redirect" status code instead
View::redirect('https://example.com', 307);
```

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307