### PR TITLE
Support unmarshalling handler parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "xp-forge/web": "^3.0 | ^2.9",
     "xp-forge/compression": "^1.0",
     "xp-forge/json": "^5.0 | ^4.0",
+    "xp-forge/marshalling": "^2.0",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/web/frontend/Delegate.class.php
+++ b/src/main/php/web/frontend/Delegate.class.php
@@ -47,12 +47,13 @@ class Delegate {
    * Returns a map of named sources to read arguments from request. Lazily
    * initialized on first use.
    *
-   * @return [:(function(web.Request, string): var)]
+   * @return [:var]
    */
   public function parameters() {
     if (null === $this->parameters) {
       $this->parameters= [];
       foreach ($this->method->parameters() as $param) {
+        $type= $param->constraint()->type();
 
         // Check for parameter annotations...
         foreach ($param->annotations() as $annotation) {
@@ -60,17 +61,17 @@ class Delegate {
           $name= $annotation->argument(0) ?? $param->name();
 
           if ($param->optional()) {
-            $this->parameters[$name]= function($req, $name) use($source, $param) {
+            $this->parameters[$name]= [$type, function($req, $name) use($source, $param) {
               return $source($req, $name) ?? $param->default();
-            };
+            }];
           } else {
-            $this->parameters[$name]= $source;
+            $this->parameters[$name]= [$type, $source];
           }
           continue 2;
         }
 
         // ...falling back to selecting the parameter from the segments
-        $this->parameters[$param->name()]= self::$SOURCES['segment'];
+        $this->parameters[$param->name()]= [$type, self::$SOURCES['segment']];
       }
     }
 

--- a/src/main/php/web/frontend/Delegate.class.php
+++ b/src/main/php/web/frontend/Delegate.class.php
@@ -47,7 +47,7 @@ class Delegate {
    * Returns a map of named sources to read arguments from request. Lazily
    * initialized on first use.
    *
-   * @return [:var]
+   * @return [:web.frontend.Parameter]
    */
   public function parameters() {
     if (null === $this->parameters) {
@@ -61,17 +61,16 @@ class Delegate {
           $name= $annotation->argument(0) ?? $param->name();
 
           if ($param->optional()) {
-            $this->parameters[$name]= [$type, function($req, $name) use($source, $param) {
+            $source= function($req, $name) use($source, $param) {
               return $source($req, $name) ?? $param->default();
-            }];
-          } else {
-            $this->parameters[$name]= [$type, $source];
+            };
           }
+          $this->parameters[$name]= new Parameter($type, $source);
           continue 2;
         }
 
         // ...falling back to selecting the parameter from the segments
-        $this->parameters[$param->name()]= [$type, self::$SOURCES['segment']];
+        $this->parameters[$param->name()]= new Parameter($type, self::$SOURCES['segment']);
       }
     }
 

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -96,8 +96,8 @@ class Frontend implements Handler {
     $marshalling= new Marshalling();
     try {
       $args= [];
-      foreach ($delegate->parameters() as $name => $spec) {
-        $args[]= $marshalling->unmarshal($matches[$name] ?? $spec[1]($req, $name), $spec[0]);
+      foreach ($delegate->parameters() as $name => $param) {
+        $args[]= $marshalling->unmarshal($matches[$name] ?? $param($req, $name), $param->type);
       }
 
       return $delegate->invoke($args);

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -1,6 +1,7 @@
 <?php namespace web\frontend;
 
 use lang\reflection\TargetException;
+use util\data\Marshalling;
 use web\{Error, Handler, Request};
 
 /**
@@ -92,10 +93,11 @@ class Frontend implements Handler {
       return $this->errors()->handle(new Error(403, 'Incorrect CSRF token for '.$delegate->name()));
     }
 
+    $marshalling= new Marshalling();
     try {
       $args= [];
-      foreach ($delegate->parameters() as $name => $source) {
-        $args[]= $matches[$name] ?? $source($req, $name);
+      foreach ($delegate->parameters() as $name => $spec) {
+        $args[]= $marshalling->unmarshal($matches[$name] ?? $spec[1]($req, $name), $spec[0]);
       }
 
       return $delegate->invoke($args);

--- a/src/main/php/web/frontend/Parameter.class.php
+++ b/src/main/php/web/frontend/Parameter.class.php
@@ -1,0 +1,27 @@
+<?php namespace web\frontend;
+
+class Parameter {
+  public $type, $source;
+
+  /**
+   * Creates a new parameter
+   * 
+   * @param  lang.Type $type
+   * @param  function(web.Request, string): var $source
+   */
+  public function __construct($type, $source) {
+    $this->type= $type;
+    $this->source= $source;
+  }
+
+  /**
+   * Reads parameter from request
+   *
+   * @param  web.Request $request
+   * @param  string $name
+   * @return var
+   */
+  public function __invoke($request, $name) {
+    return ($this->source)($request, $name);
+  }
+}

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -27,7 +27,7 @@ class HandlersInTest {
         '#get/users/(?<id>[^/]+)/avatar$#',
         '#delete/users/(?<id>[^/]+)$#',
         '#get/users/(?<id>[^/]+)$#',
-        '#get/posts/(?<id>[^/]+)$#',
+        '#get/post/(?<id>[^/]+)$#',
         '#get/blogs/stats$#',
         '#get/blogs/?$#',
         '#post/users$#',

--- a/src/test/php/web/frontend/unittest/HandlersInTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlersInTest.class.php
@@ -27,6 +27,7 @@ class HandlersInTest {
         '#get/users/(?<id>[^/]+)/avatar$#',
         '#delete/users/(?<id>[^/]+)$#',
         '#get/users/(?<id>[^/]+)$#',
+        '#get/posts/(?<id>[^/]+)$#',
         '#get/blogs/stats$#',
         '#get/blogs/?$#',
         '#post/users$#',

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -3,7 +3,7 @@
 use lang\IndexOutOfBoundsException;
 use test\Assert;
 use test\{Expect, Test, TestCase, Values};
-use web\frontend\unittest\actions\{Blogs, Home, Select, Users};
+use web\frontend\unittest\actions\{Blogs, Home, Select, Users, Posts};
 use web\frontend\{Frontend, Templates, View};
 use web\io\{TestInput, TestOutput};
 use web\{Error, Request, Response};
@@ -407,5 +407,17 @@ class HandlingTest {
 
     $res= $this->handle($fixture, 'HEAD', '/users/1');
     Assert::equals("\r\n\r\n", strstr($res->output()->bytes(), "\r\n\r\n"));
+  }
+
+  #[Test]
+  public function marshals_to_custom_input() {
+    $fixture= new Frontend(new Posts(), newinstance(Templates::class, [], [
+      'write' => function($template, $context, $out) use(&$result) {
+        $result= $context;
+      }
+    ]));
+
+    $this->handle($fixture, 'GET', '/posts/1234');
+    $this->assertContext(['id' => '1234', 'request' => ['params' => []]], $result);
   }
 }

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -417,7 +417,7 @@ class HandlingTest {
       }
     ]));
 
-    $this->handle($fixture, 'GET', '/posts/1234');
+    $this->handle($fixture, 'GET', '/post/1234');
     $this->assertContext(['id' => '1234', 'request' => ['params' => []]], $result);
   }
 }

--- a/src/test/php/web/frontend/unittest/ObjectId.class.php
+++ b/src/test/php/web/frontend/unittest/ObjectId.class.php
@@ -1,0 +1,12 @@
+<?php namespace web\frontend\unittest;
+
+class ObjectId {
+  private $id;
+
+  public function __construct($id) {
+    $this->id= (string)$id;
+  }
+
+
+  public function string() { return $this->id; }
+}

--- a/src/test/php/web/frontend/unittest/actions/Posts.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Posts.class.php
@@ -1,0 +1,13 @@
+<?php namespace web\frontend\unittest\actions;
+
+use web\frontend\unittest\ObjectId;
+use web\frontend\{Handler, Get};
+
+#[Handler('/posts')]
+class Posts {
+
+  #[Get('/{id}')]
+  public function get(ObjectId $id) {
+    return ['id' => $id->string()];
+  }
+}

--- a/src/test/php/web/frontend/unittest/actions/Posts.class.php
+++ b/src/test/php/web/frontend/unittest/actions/Posts.class.php
@@ -3,7 +3,7 @@
 use web\frontend\unittest\ObjectId;
 use web\frontend\{Handler, Get};
 
-#[Handler('/posts')]
+#[Handler('/post')]
 class Posts {
 
   #[Get('/{id}')]


### PR DESCRIPTION
Example:

```php
use com\example\ObjectId;
use web\frontend\{Handler, Get};

#[Handler('/posts')]
class Posts {

  #[Get('/{id}')]
  public function get(ObjectId $id) {
    return ['id' => $id->string()];
  }
}
```

This would previously raise the following error: *Argument 1 ($id) must be of type com\example\ObjectId, string given*. This pull request makes this library behave consistently with https://github.com/xp-forge/rest-api 