### PR TITLE
Add support for setting the `Last-Modified` header easily

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -1,5 +1,8 @@
 <?php namespace web\frontend;
 
+use util\Date;
+use web\Headers;
+
 /** @test web.frontend.unittest.ViewTest */
 class View {
   public $template;
@@ -149,6 +152,21 @@ class View {
    */
   public function cache($control) {
     $this->headers['Cache-Control']= $control;
+    return $this;
+  }
+
+  /**
+   * Sets `Last-Modified` to header
+   *
+   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests
+   * @param  ?int|float|string|util.Date $date
+   * @return self
+   */
+  public function modified($date) {
+    $this->headers['Last-Modified']= Headers::date(null === $date
+      ? Date::now()
+      : ($date instanceof Date ? $date : new Date($date))
+    );
     return $this;
   }
 

--- a/src/test/php/web/frontend/unittest/ViewTest.class.php
+++ b/src/test/php/web/frontend/unittest/ViewTest.class.php
@@ -1,9 +1,23 @@
 <?php namespace web\frontend\unittest;
 
-use test\{Assert, Test};
+use test\{Assert, Test, Values};
+use util\Date;
 use web\frontend\View;
 
 class ViewTest {
+
+  /** @return iterable */
+  private function modifications() {
+
+    // Current date
+    yield [null, gmdate('D, d M Y H:i:s \G\M\T')];
+
+    // Reference date
+    $date= 'Mon, 25 Nov 2024 19:30:00 GMT';
+    yield [strtotime($date), $date];
+    yield [$date, $date];
+    yield [new Date($date), $date];
+  }
 
   #[Test]
   public function template() {
@@ -56,6 +70,11 @@ class ViewTest {
       'image/png',
       View::named('test')->header('Content-Type', 'image/png')->headers['Content-Type']
     );
+  }
+
+  #[Test, Values(from: 'modifications')]
+  public function modified($date, $expected) {
+    Assert::equals($expected, View::named('test')->modified($date)->headers['Last-Modified']);
   }
 
   #[Test]


### PR DESCRIPTION
Example of how this simplifies calling code:

```diff
-use web\Headers;

 $items= $this->repository->newest(20);
 return View::named('blog')
-  ->header('Last-Modified', Headers::date($items[0]['date'] ?? null))
+  ->modified($items[0]['date'] ?? null)
   ->with(['items' => $items])
 ;
```

Example would be to use this as part of https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests