### PR TITLE
Create dedicated "cannot route" error

### DIFF
--- a/src/main/php/web/frontend/CannotRoute.class.php
+++ b/src/main/php/web/frontend/CannotRoute.class.php
@@ -1,0 +1,20 @@
+<?php namespace web\frontend;
+
+use web\Error;
+
+class CannotRoute extends Error {
+  public $method, $path;
+
+  /**
+   * Creates a new *cannot route* error
+   *
+   * @param  string $method
+   * @param  string $path
+   * @param  lang.Throwable $cause
+   */
+  public function __construct($method, $path, $cause= null) {
+    parent::__construct(404, "Cannot route {$method} requests to {$path}", $cause);
+    $this->method= $method;
+    $this->path= $path;
+  }
+}

--- a/src/main/php/web/frontend/Frontend.class.php
+++ b/src/main/php/web/frontend/Frontend.class.php
@@ -85,7 +85,7 @@ class Frontend implements Handler {
     static $CSRF_EXEMPT= ['get' => true, 'head' => true];
 
     if (null === $delegate) {
-      return $this->errors()->handle(new Error(404, 'Cannot route '.$req->method().' requests to '.$req->uri()->path()));
+      return $this->errors()->handle(new CannotRoute($req->method(), $req->uri()->path()));
     }
 
     // Verify CSRF token for anything which is not a GET or HEAD request

--- a/src/test/php/web/frontend/unittest/HandlingTest.class.php
+++ b/src/test/php/web/frontend/unittest/HandlingTest.class.php
@@ -4,7 +4,7 @@ use lang\IndexOutOfBoundsException;
 use test\Assert;
 use test\{Expect, Test, TestCase, Values};
 use web\frontend\unittest\actions\{Blogs, Home, Select, Users, Posts};
-use web\frontend\{Frontend, Templates, View};
+use web\frontend\{Frontend, Templates, View, CannotRoute};
 use web\io\{TestInput, TestOutput};
 use web\{Error, Request, Response};
 
@@ -172,7 +172,7 @@ class HandlingTest {
     Assert::equals(404, $res->status());
   }
 
-  #[Test, Expect(class: Error::class, message: '/Cannot route PATCH requests to .+/')]
+  #[Test, Expect(class: CannotRoute::class, message: '/Cannot route PATCH requests to .+/')]
   public function unsupported_route() {
     $fixture= new Frontend(new Users(), new class() implements Templates {
       public function write($template, $context, $out) { /* NOOP */ }


### PR DESCRIPTION
This pull request makes it easier to handle 404 errors. The class `web.frontend.CannotRoute` extends the `web.Error` class, retaining BC.