### PR TITLE
Make it possible to supply `Content-Type` parameters

### DIFF
--- a/src/main/php/web/frontend/View.class.php
+++ b/src/main/php/web/frontend/View.class.php
@@ -146,10 +146,18 @@ class View {
   /**
    * Sets `Content-Type` header
    *
+   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Type
    * @param  string $mime Header value
+   * @param  [:string] $params
    * @return self
    */
-  public function type($mime) {
+  public function type($mime, $params= []) {
+    foreach ($params as $key => $value) {
+      $mime.= '; '.$key.'='.(strlen($value) === strcspn($value, "()<>@,;:\\\"/[]?={} \t")
+        ? $value
+        : '"'.strtr($value, ['"' => '\\"']).'"'
+      );
+    }
     $this->headers['Content-Type']= $mime;
     return $this;
   }
@@ -157,7 +165,7 @@ class View {
   /**
    * Sets `Cache-Control` header, which defaults to "no-cache"
    *
-   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+   * @see    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
    * @param  string $control Header value
    * @return self
    */

--- a/src/test/php/web/frontend/unittest/ViewTest.class.php
+++ b/src/test/php/web/frontend/unittest/ViewTest.class.php
@@ -67,6 +67,14 @@ class ViewTest {
     );
   }
 
+  #[Test, Values([[[], ''], [['charset' => 'utf-8'], '; charset=utf-8'], [['boundary' => 'a;b'], '; boundary="a;b"']])]
+  public function content_type_with_type($params, $expected) {
+    Assert::equals(
+      "text/plain{$expected}",
+      View::named('test')->type('text/plain', $params)->headers['Content-Type']
+    );
+  }
+
   #[Test]
   public function empty() {
     Assert::null(View::empty()->template);


### PR DESCRIPTION
Example:

```diff
   $view
     ->cache('public, max-age=3600')
-    ->type('application/atom+xml; charset=utf-8')
+    ->type('application/atom+xml', ['charset' => 'utf-8'])
   ;
```